### PR TITLE
chore: release zorphy_annotation 1.1.0

### DIFF
--- a/zorphy/CHANGELOG.md
+++ b/zorphy/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+## [1.1.0] - 2026-02-05
+
+### Change
+- Fixed an edge case where a class extends a sealed class and implements another class was causing parameters not passed in super constructor
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -588,10 +588,9 @@ packages:
   zorphy_annotation:
     dependency: "direct main"
     description:
-      name: zorphy_annotation
-      sha256: "30bb01562a691315e885f8a6dd66508fb8beb8ec50c7c8fadd099856f9b869f0"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zorphy_annotation"
+      relative: true
+    source: path
     version: "1.0.0"
 sdks:
   dart: ">=3.9.0 <4.0.0"

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -588,9 +588,10 @@ packages:
   zorphy_annotation:
     dependency: "direct main"
     description:
-      path: "../zorphy_annotation"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: zorphy_annotation
+      sha256: "2ac049077f84059609c0889b96431bcfcbed2c0b5ab075bacf07829bb6b1a7bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.9.0 <4.0.0"

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  zorphy_annotation:
-    path: ../zorphy_annotation
+  zorphy_annotation: ^1.1.1
   analyzer: ^10.0.2
   build: ^4.0.4
   source_gen: ^4.2.0

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -1,13 +1,13 @@
 name: zorphy
 description: A powerful code generation package for Dart/Flutter that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  zorphy_annotation: ^1.1.1
+  zorphy_annotation: ^1.1.0
   analyzer: ^10.0.2
   build: ^4.0.4
   source_gen: ^4.2.0

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -7,7 +7,8 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  zorphy_annotation: ^1.0.0
+  zorphy_annotation:
+    path: ../zorphy_annotation
   analyzer: ^10.0.2
   build: ^4.0.4
   source_gen: ^4.2.0

--- a/zorphy_annotation/CHANGELOG.md
+++ b/zorphy_annotation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+## [1.1.0] - 2026-02-05
+
+### Change
+- Fixed an edge case where a class extends a sealed class and implements another class was causing parameters not passed in super constructor
+
 ## [1.0.0] - 2026-02-04
 
 ## [1.0.0] - 2026-02-04

--- a/zorphy_annotation/CHANGELOG.md
+++ b/zorphy_annotation/CHANGELOG.md
@@ -7,14 +7,6 @@
 
 ## [1.0.0] - 2026-02-04
 
-## [1.0.0] - 2026-02-04
-
-## [1.0.0] - 2026-02-04
-
-## [1.0.0] - 2026-02-04
-
-## [1.0.0] - 2026-02-04
-
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/zorphy_annotation/pubspec.yaml
+++ b/zorphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zorphy_annotation
 description: Annotations for zorphy code generation package that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:


### PR DESCRIPTION
Release zorphy_annotation 1.1.0

**Description:** Fixed an edge case where a class extends a sealed class and implements another class was causing parameters not passed in super constructor

**Date:** 2026-02-05

**Changes:**
- Bump version to 1.1.0
- Update CHANGELOG.md

Please review and merge this PR to master before proceeding with the release.