### PR TITLE
chore: release zorphy_annotation 1.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Add the dependencies to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zorphy_annotation: ^1.6.6
+  zorphy_annotation: ^1.6.7
 
 dev_dependencies:
-  zorphy: ^1.6.6
+  zorphy: ^1.6.7
   build_runner: ^2.4.0
 ```
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -305,12 +305,36 @@ cd zorphy
 
 # Update zorphy_annotation dependency in pubspec.yaml to match version
 echo "📝 Updating zorphy_annotation dependency in zorphy/pubspec.yaml..."
-perl -i -0777 -pe "s/^  zorphy_annotation:\s*\n\s*path:\s*\.\.\/zorphy_annotation\n/  zorphy_annotation: ^$VERSION\n/g; s/^  zorphy_annotation:\s*\S+\n/  zorphy_annotation: ^$VERSION\n/g" pubspec.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^  zorphy_annotation:.*/  zorphy_annotation: ^$VERSION/" pubspec.yaml
+else
+    sed -i "s/^  zorphy_annotation:.*/  zorphy_annotation: ^$VERSION/" pubspec.yaml
+fi
 echo "  ✓ Dependency updated to ^$VERSION"
+
+# Remove path overrides from pubspec_overrides.yaml before publishing
+if [ -f "pubspec_overrides.yaml" ]; then
+    echo "📝 Cleaning pubspec_overrides.yaml path overrides..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' '/^\s*zorphy_annotation:/d' pubspec_overrides.yaml
+        sed -i '' '/^\s*path:\s*\.\.\/zorphy_annotation/d' pubspec_overrides.yaml
+    else
+        sed -i '/^\s*zorphy_annotation:/d' pubspec_overrides.yaml
+        sed -i '/^\s*path:\s*\.\.\/zorphy_annotation/d' pubspec_overrides.yaml
+    fi
+    remaining=$(grep -v '^\s*#' pubspec_overrides.yaml | grep -v '^\s*$' || true)
+    if [ -z "$remaining" ]; then
+        rm -f pubspec_overrides.yaml
+        git add pubspec_overrides.yaml
+        echo "  ✓ Removed empty pubspec_overrides.yaml"
+    else
+        echo "  ✓ Cleaned path overrides from pubspec_overrides.yaml"
+    fi
+fi
 
 # Commit changes
 echo "🔨 Committing zorphy changes..."
-git add pubspec.yaml CHANGELOG.md
+git add pubspec.yaml pubspec_overrides.yaml CHANGELOG.md 2>/dev/null || git add pubspec.yaml CHANGELOG.md
 git commit -m "chore: release zorphy $VERSION" || true
 echo "  ✓ Changes committed"
 

--- a/zorphy/CHANGELOG.md
+++ b/zorphy/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.7] - 2026-04-06
+
+### Fix
+- Factory method parameter types now preserve import prefixes (`as` clauses) in generated code
+
 ## [1.6.6] - 2026-04-05
 
 ### Feature

--- a/zorphy/lib/src/analysis/class_analyzer.dart
+++ b/zorphy/lib/src/analysis/class_analyzer.dart
@@ -367,6 +367,7 @@ class ClassAnalyzer {
       var paramType = common_helpers.typeToString(
         param.type,
         currentClassName: classNameTrimmed,
+        library: classElement.library,
       );
 
       // CRITICAL FIX: If type is still InvalidType, try to recover from source code directly

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -559,6 +559,6 @@ packages:
       path: "../zorphy_annotation"
       relative: true
     source: path
-    version: "1.6.6"
+    version: "1.6.7"
 sdks:
   dart: ">=3.10.0 <4.0.0"

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -1,13 +1,13 @@
 name: zorphy
 description: A powerful code generation package for Dart/Flutter that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 1.6.6
+version: 1.6.7
 homepage: https://github.com/arrrrny/zorphy
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  zorphy_annotation: ^1.6.6
+  zorphy_annotation: ^1.6.7
   analyzer: ^12.0.0
   build: ^4.0.4
   source_gen: ^4.2.0

--- a/zorphy_annotation/CHANGELOG.md
+++ b/zorphy_annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.7] - 2026-04-06
+
+### 
+- 
+
 ## [1.6.6] - 2026-04-05
 
 ### Feature
@@ -180,7 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feature reference
 - Real-world usage examples
 
-[Unreleased]: https://github.com/arrrrny/zorphy/compare/annotation-v1.6.5...HEAD
+[Unreleased]: https://github.com/arrrrny/zorphy/compare/annotation-v1.6.7...HEAD
 [1.5.6]: https://github.com/arrrrny/zorphy/compare/v1.5.5...v1.5.6
 [1.6.1]: https://github.com/arrrrny/zorphy/compare/annotation-v1.5.6...annotation-v1.6.1
 [1.5.5]: https://github.com/arrrrny/zorphy/compare/v1.5.4...v1.5.5

--- a/zorphy_annotation/pubspec.yaml
+++ b/zorphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zorphy_annotation
 description: Annotations for zorphy code generation package that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 1.6.6
+version: 1.6.7
 homepage: https://github.com/arrrrny/zorphy
 
 environment:


### PR DESCRIPTION
Release zorphy_annotation 1.6.7

**Description:** 

**Date:** 2026-04-06

**Changes:**
- Bump version to 1.6.7
- Update CHANGELOG.md

Please review and merge this PR to master before proceeding with the release.