### PR TITLE
feat: SpecMapper — analyzer-to-code_builder spec bridge

### DIFF
--- a/zorphy/lib/src/ast/ast.dart
+++ b/zorphy/lib/src/ast/ast.dart
@@ -1,7 +1,8 @@
 /// AST helper types for code_builder-based generation.
 ///
-/// Provides escape-free type-reference utilities that produce
-/// [TypeReference] objects suitable for [Spec] instances.
+/// Provides escape-free type-reference utilities and spec-mapping
+/// functions that produce [Spec] instances from Zorphy analyzer models.
 library;
 
 export 'type_ref.dart';
+export 'spec_mapper.dart';

--- a/zorphy/lib/src/ast/spec_mapper.dart
+++ b/zorphy/lib/src/ast/spec_mapper.dart
@@ -1,0 +1,162 @@
+/// SpecMapper: bridges Zorphy analyzer models to code_builder specs.
+///
+/// Converts [ClassMetadata], [FieldMetadata], [InterfaceMetadata], and
+/// [GenericParameterMetadata] into their [code_builder] equivalents
+/// ([Class], [Field], [TypeReference], [TypeParameter]).
+///
+/// Downstream generator migrations (P3) will call these functions to
+/// build specs instead of concatenating strings.
+library;
+
+import 'package:code_builder/code_builder.dart';
+
+import '../models/class_metadata.dart';
+import '../models/field_metadata.dart';
+import '../models/interface_metadata.dart';
+import 'type_ref.dart';
+
+// ────────────────────────────────────────────────────────────────────
+// Class mapping
+// ────────────────────────────────────────────────────────────────────
+
+/// Maps a [ClassMetadata] to a code_builder [Class] spec.
+///
+/// Handles:
+/// - **Modifiers**: `abstract`, `sealed`, plain concrete.
+///   A class that is both abstract and sealed gets `sealed`; an abstract
+///   class that is NOT sealed gets `abstract`. Concrete classes get no
+///   modifier.
+/// - **Type parameters**: [ClassMetadata.generics] are mapped via
+///   [mapGenericParameter].
+/// - **Implements clauses**: [ClassMetadata.interfaces] are mapped via
+///   [mapInterfaceToTypeReference].
+///
+/// The returned [Class] only contains the **structural shape** (name,
+/// modifiers, type params, implements).  Fields and methods are NOT
+/// included — downstream generators add those per their own migration.
+Class mapClass(ClassMetadata meta) {
+  return Class((c) {
+    c.name = meta.cleanName;
+
+    // ── Modifiers ──────────────────────────────────────────────────
+    if (meta.isSealed) {
+      c.sealed = true;
+    } else if (meta.isAbstract) {
+      c.abstract = true;
+    }
+    // concrete: no modifier needed
+
+    // ── Type parameters ────────────────────────────────────────────
+    for (final g in meta.generics) {
+      c.types.add(mapGenericParameter(g));
+    }
+
+    // ── Implements clauses ─────────────────────────────────────────
+    for (final iface in meta.interfaces) {
+      c.implements.add(mapInterfaceToTypeReference(iface));
+    }
+
+    // ── Doc comment ────────────────────────────────────────────────
+    if (meta.docComment.isNotEmpty) {
+      c.docs.add(meta.docComment);
+    }
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Field mapping
+// ────────────────────────────────────────────────────────────────────
+
+/// Maps a [FieldMetadata] (= [NameTypeClassComment]) to a code_builder
+/// [Field] spec.
+///
+/// The field's type string is resolved through [referType] so that
+/// generics (e.g. `List<int>`, `Map<String, dynamic>?`) are correctly
+/// represented as nested [TypeReference]s.
+///
+/// Notes:
+/// - `final` is inferred from the Zorphy convention (all generated
+///   fields are final). If the field has `isGetterOnly`, no `final`
+///   keyword is added.
+/// - Annotations from [JsonKeyInfo] are attached as raw [Code] specs.
+Field mapField(FieldMetadata field) {
+  return Field((f) {
+    f.name = field.name;
+    f.type = field.type != null ? referType(field.type!) : referType('dynamic');
+
+    // Zorphy fields are final unless they are getter-only.
+    f.modifier = field.isGetterOnly ? FieldModifier.var$ : FieldModifier.final$;
+
+    // Doc comment
+    if (field.comment != null && field.comment!.isNotEmpty) {
+      f.docs.add(field.comment!);
+    }
+
+    // JsonKey annotation
+    if (field.jsonKeyInfo != null && field.jsonKeyInfo!.hasAnnotations) {
+      f.annotations.add(
+        CodeExpression(Code(field.jsonKeyInfo!.toAnnotationString())),
+      );
+    }
+
+    // Additional annotations (e.g. @JsonSerializable, custom ones)
+    for (final ann in field.additionalAnnotations) {
+      f.annotations.add(CodeExpression(Code(ann)));
+    }
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Interface mapping
+// ────────────────────────────────────────────────────────────────────
+
+/// Maps an [InterfaceMetadata] to a [TypeReference] suitable for an
+/// `implements` clause.
+///
+/// Handles generic type arguments — e.g. `Comparable<T>` becomes
+/// `TypeReference(symbol: 'Comparable', types: [refer('T')])`.
+TypeReference mapInterfaceToTypeReference(InterfaceMetadata iface) {
+  final name = iface.interfaceName;
+  final typeRefs =
+      iface.typeParams
+          .where((tp) => tp.name.isNotEmpty)
+          .map((tp) {
+            if (tp.type != null && tp.type!.isNotEmpty) {
+              return referType('${tp.name}<${tp.type}>');
+            }
+            return referType(tp.name);
+          })
+          .toList();
+
+  if (typeRefs.isEmpty) {
+    return referType(name);
+  }
+
+  return TypeReference((t) {
+    t.symbol = name;
+    t.types.addAll(typeRefs);
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Generic parameter mapping
+// ────────────────────────────────────────────────────────────────────
+
+/// Maps a [GenericParameterMetadata] to a code_builder [TypeReference]
+/// suitable for a class `types` list.
+///
+/// In code_builder 4.x, type parameters with bounds are represented as
+/// [TypeReference] with the [TypeReference.bound] set.
+///
+/// ```dart
+/// // GenericParameterMetadata(name: 'T', bound: 'num')
+/// //   => TypeReference(symbol: 'T', bound: referType('num'))
+/// ```
+TypeReference mapGenericParameter(GenericParameterMetadata g) {
+  return TypeReference((t) {
+    t.symbol = g.name;
+    if (g.bound != null) {
+      t.bound = referType(g.bound!);
+    }
+  });
+}

--- a/zorphy/test/ast/spec_mapper_test.dart
+++ b/zorphy/test/ast/spec_mapper_test.dart
@@ -1,0 +1,323 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:zorphy/src/ast/spec_mapper.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/interface_metadata.dart';
+
+// ────────────────────────────────────────────────────────────────────
+// Minimal ClassElement stub for unit testing
+// ────────────────────────────────────────────────────────────────────
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+
+  _StubClassElement(this.name);
+
+  // No-op implementations for the rest of the ClassElement interface.
+  // Only [name] is used by the mapper (for nothing — it's just stored).
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────
+
+/// Creates a minimal [ClassMetadata] for testing the mapper.
+/// Only the fields relevant to spec mapping are populated.
+ClassMetadata _testMeta({
+  required String originalName,
+  required bool isAbstract,
+  required bool isSealed,
+  bool nonSealed = false,
+  String docComment = '',
+  List<GenericParameterMetadata> generics = const [],
+  List<InterfaceMetadata> interfaces = const [],
+}) {
+  final cleanName = originalName.replaceAll(r'$', '');
+  return ClassMetadata(
+    originalName: originalName,
+    cleanName: cleanName,
+    isAbstract: isAbstract,
+    isSealed: isSealed,
+    nonSealed: nonSealed,
+    hasConstConstructor: false,
+    docComment: docComment,
+    generics: generics,
+    interfaces: interfaces,
+    allValueTInterfaces: const [],
+    allFields: const [],
+    ownFieldNames: const {},
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(cleanName),
+    allAnnotatedClasses: const {},
+  );
+}
+
+/// Creates a minimal [InterfaceMetadata] for testing.
+/// Uses a stub [ClassElement].
+InterfaceMetadata _testInterface({
+  required String name,
+  List<NameType> typeParams = const [],
+  List<NameType> fields = const [],
+}) {
+  return InterfaceMetadata(
+    name,
+    typeParams.map((tp) => tp.type).toList(),
+    typeParams.map((tp) => tp.name).toList(),
+    fields,
+    element: _StubClassElement(name),
+  );
+}
+
+/// Convenience: emits a [Class] spec to a Dart source string for assertion.
+String _emitClass(Class spec) {
+  final lib = Library((b) => b.body.add(spec));
+  final raw = lib.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+  return raw;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+
+void main() {
+  // ── mapGenericParameter ──────────────────────────────────────────
+  group('mapGenericParameter', () {
+    test('unbounded type parameter', () {
+      final tp = mapGenericParameter(
+        const GenericParameterMetadata(name: 'T'),
+      );
+      expect(tp.symbol, 'T');
+      expect(tp.bound, isNull);
+    });
+
+    test('bounded type parameter', () {
+      final tp = mapGenericParameter(
+        const GenericParameterMetadata(name: 'T', bound: 'num'),
+      );
+      expect(tp.symbol, 'T');
+      expect(tp.bound, isNotNull);
+      // The bound is a TypeReference; check its symbol.
+      final boundStr = tp.bound!.accept(DartEmitter()).toString();
+      expect(boundStr, 'num');
+    });
+
+    test('bounded type parameter with generic bound', () {
+      final tp = mapGenericParameter(
+        const GenericParameterMetadata(name: 'K', bound: 'Comparable<K>'),
+      );
+      expect(tp.symbol, 'K');
+      final boundStr = tp.bound!.accept(DartEmitter()).toString();
+      expect(boundStr, 'Comparable<K>');
+    });
+  });
+
+  // ── mapField ──────────────────────────────────────────────────────
+  group('mapField', () {
+    test('simple field with type', () {
+      final field = mapField(
+        NameTypeClassComment('name', 'String', 'User'),
+      );
+      expect(field.name, 'name');
+      // Type should be 'String'.
+      final typeStr = field.type!.accept(DartEmitter()).toString();
+      expect(typeStr, 'String');
+      // Should be final by default.
+      expect(field.modifier, FieldModifier.final$);
+    });
+
+    test('getter-only field is var, not final', () {
+      final field = mapField(
+        NameTypeClassComment('items', 'List<int>', 'Box', isGetterOnly: true),
+      );
+      expect(field.modifier, FieldModifier.var$);
+    });
+
+    test('nullable field type preserved', () {
+      final field = mapField(
+        NameTypeClassComment('value', 'int?', 'Item'),
+      );
+      final typeStr = field.type!.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+      expect(typeStr, 'int?');
+    });
+
+    test('generic field type preserved', () {
+      final field = mapField(
+        NameTypeClassComment('data', 'Map<String, dynamic>', 'Record'),
+      );
+      // Raw emitter output is structurally correct; spacing is a formatter concern.
+      final typeStr = field.type!.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+      expect(typeStr, contains('Map<String,'));
+      expect(typeStr, contains(',dynamic>'));
+    });
+
+    test('field with doc comment', () {
+      final field = mapField(
+        NameTypeClassComment('id', 'String', 'User', comment: 'The unique ID'),
+      );
+      expect(field.docs, contains('The unique ID'));
+    });
+
+    test('field with JsonKey annotation', () {
+      const jsonKey = JsonKeyInfo(name: 'user_name');
+      final field = mapField(
+        NameTypeClassComment('name', 'String', 'User', jsonKeyInfo: jsonKey),
+      );
+      // Should have one annotation.
+      expect(field.annotations.length, 1);
+    });
+
+    test('field without type defaults to dynamic', () {
+      final field = mapField(
+        NameTypeClassComment('anything', null, 'Thing'),
+      );
+      final typeStr = field.type!.accept(DartEmitter()).toString();
+      expect(typeStr, 'dynamic');
+    });
+  });
+
+  // ── mapInterfaceToTypeReference ────────────────────────────────────
+  group('mapInterfaceToTypeReference', () {
+    test('simple interface without type params', () {
+      final iface = _testInterface(name: 'Serializable');
+      final ref = mapInterfaceToTypeReference(iface);
+      final str = ref.accept(DartEmitter()).toString();
+      expect(str, 'Serializable');
+    });
+
+    test('interface with type params', () {
+      final iface = _testInterface(
+        name: 'Comparable',
+        typeParams: [NameType('T', '')],
+      );
+      final ref = mapInterfaceToTypeReference(iface);
+      final str = ref.accept(DartEmitter()).toString();
+      expect(str, 'Comparable<T>');
+    });
+  });
+
+  // ── mapClass ──────────────────────────────────────────────────────
+  group('mapClass', () {
+    test('abstract class shape (\$\$Shape → abstract class Shape)', () {
+      final meta = _testMeta(
+        originalName: r'$$Shape',
+        isAbstract: true,
+        isSealed: false,
+      );
+      final cls = mapClass(meta);
+      expect(cls.name, 'Shape');
+      expect(cls.abstract, true);
+      expect(cls.sealed, false);
+
+      final emitted = _emitClass(cls);
+      expect(emitted, contains('abstract class Shape'));
+    });
+
+    test('sealed class shape (\$\$Shape with !nonSealed → sealed class Shape)', () {
+      final meta = _testMeta(
+        originalName: r'$$Shape',
+        isAbstract: true,
+        isSealed: true,
+      );
+      final cls = mapClass(meta);
+      expect(cls.name, 'Shape');
+      expect(cls.sealed, true);
+      // In code_builder, sealed classes are NOT marked abstract separately.
+      // The 'sealed' keyword implies abstract.
+
+      final emitted = _emitClass(cls);
+      expect(emitted, contains('sealed class Shape'));
+    });
+
+    test('concrete class shape (\$User → class User)', () {
+      final meta = _testMeta(
+        originalName: r'$User',
+        isAbstract: false,
+        isSealed: false,
+      );
+      final cls = mapClass(meta);
+      expect(cls.name, 'User');
+      expect(cls.abstract, false);
+      expect(cls.sealed, false);
+
+      final emitted = _emitClass(cls);
+      expect(emitted, contains('class User'));
+      expect(emitted, isNot(contains('abstract')));
+      expect(emitted, isNot(contains('sealed')));
+    });
+
+    test('generic class shape (\$Box<T> → class Box<T>)', () {
+      final meta = _testMeta(
+        originalName: r'$Box',
+        isAbstract: false,
+        isSealed: false,
+        generics: const [
+          GenericParameterMetadata(name: 'T'),
+        ],
+      );
+      final cls = mapClass(meta);
+      expect(cls.name, 'Box');
+      expect(cls.types.length, 1);
+      expect(cls.types[0].symbol, 'T');
+
+      final emitted = _emitClass(cls);
+      expect(emitted, contains('class Box<T>'));
+    });
+
+    test('generic class with bounded type param (Map type param preservation)', () {
+      final meta = _testMeta(
+        originalName: r'$SortedMap',
+        isAbstract: false,
+        isSealed: false,
+        generics: const [
+          GenericParameterMetadata(name: 'K', bound: 'Comparable<K>'),
+          GenericParameterMetadata(name: 'V'),
+        ],
+      );
+      final cls = mapClass(meta);
+      expect(cls.types.length, 2);
+      expect(cls.types[0].symbol, 'K');
+      expect(cls.types[1].symbol, 'V');
+
+      final emitted = _emitClass(cls);
+      // Raw emitter omits spaces after commas in type param lists.
+      expect(emitted, contains('class SortedMap<K extends Comparable<K>,'));
+      expect(emitted, contains(',V>'));
+    });
+
+    test('class with implements clause', () {
+      final meta = _testMeta(
+        originalName: r'$User',
+        isAbstract: false,
+        isSealed: false,
+        interfaces: [
+          _testInterface(name: 'Serializable'),
+          _testInterface(name: 'Comparable', typeParams: [NameType('User', '')]),
+        ],
+      );
+      final cls = mapClass(meta);
+      expect(cls.implements.length, 2);
+
+      final emitted = _emitClass(cls);
+      expect(emitted, contains('implements Serializable'));
+      expect(emitted, contains('Comparable<User>'));
+    });
+
+    test('class with doc comment', () {
+      final meta = _testMeta(
+        originalName: r'$User',
+        isAbstract: false,
+        isSealed: false,
+        docComment: 'A user in the system.',
+      );
+      final cls = mapClass(meta);
+      expect(cls.docs, contains('A user in the system.'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #29

## Summary
Created the SpecMapper bridging ClassMetadata/FieldMetadata/InterfaceMetadata to code_builder specs.

### Tasks
- T006: Created lib/src/ast/spec_mapper.dart
- T007: Added test/ast/spec_mapper_test.dart covering abstract/sealed/concrete/generic shapes

## Verification
- dart analyze: 0 new issues
- dart test: 41 passed (19 new + 22 existing), 2 pre-existing fixture failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public AST specification mapping for classes, fields, interfaces, and generic parameters.
  * Supports modifiers, documentation, annotations, type references, generic bounds, and interface arguments.

* **Tests**
  * Added comprehensive coverage for mapping generic, abstract, sealed, documented, and interface-based classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->