### PR TITLE
feat: plugin API & registry (ZorphyPlugin contract)

### DIFF
--- a/zorphy/lib/builder.dart
+++ b/zorphy/lib/builder.dart
@@ -4,13 +4,42 @@ import 'package:source_gen/source_gen.dart';
 import 'src/zorphy_generator.dart';
 
 /// Creates the build_runner builder for Zorphy code generation.
+///
+/// If the `plugins` builder option is provided (a list of import-URI
+/// strings), those URIs are passed to [ZorphyGenerator] which stores
+/// them for deferred plugin resolution at generate() time.
+///
+/// Example `build.yaml`:
+/// ```yaml
+/// targets:
+///   $default:
+///     builders:
+///       zorphy:
+///         options:
+///           plugins:
+///             - package:my_plugin/my_plugin.dart
+/// ```
+///
+/// When no `plugins` option is present, behavior is byte-identical
+/// to the pre-plugin pipeline (zero regressions).
 Builder zorphyBuilder(BuilderOptions options) {
+  final pluginUris = _extractPluginUris(options);
   return PartBuilder(
-    [ZorphyGenerator()],
+    [ZorphyGenerator(pluginUris: pluginUris)],
     '.zorphy.dart',
     header: '''
 // ignore_for_file: UNNECESSARY_CAST
 // ignore_for_file: type=lint
 ''',
   );
+}
+
+/// Extracts the `plugins` list from builder options.
+///
+/// Returns an empty list if the key is missing, not a [List],
+/// or contains non-[String] entries (which are silently skipped).
+List<String> _extractPluginUris(BuilderOptions options) {
+  final raw = options.config['plugins'];
+  if (raw is! List) return const [];
+  return raw.whereType<String>().toList();
 }

--- a/zorphy/lib/builder.dart
+++ b/zorphy/lib/builder.dart
@@ -5,11 +5,12 @@ import 'src/zorphy_generator.dart';
 
 /// Creates the build_runner builder for Zorphy code generation.
 ///
-/// If the `plugins` builder option is provided (a list of import-URI
-/// strings), those URIs are passed to [ZorphyGenerator] which stores
-/// them for deferred plugin resolution at generate() time.
+/// **Note:** The `plugins` builder option is currently reserved for
+/// future use (v2.1+). URI-based plugin loading is not yet implemented.
+/// For now, plugins must be registered programmatically by passing a
+/// pre-populated [PluginRegistry] to [ZorphyGenerator].
 ///
-/// Example `build.yaml`:
+/// Example `build.yaml` (future feature):
 /// ```yaml
 /// targets:
 ///   $default:

--- a/zorphy/lib/src/orchestrator.dart
+++ b/zorphy/lib/src/orchestrator.dart
@@ -116,6 +116,11 @@ class Orchestrator {
   /// Plugins mutate the [Class], [Method], and [Field] specs
   /// in-place. Imports and diagnostics accumulate into the
   /// [PluginContext].
+  ///
+  /// Plugins are filtered by [ZorphyPlugin.decoratorNames]: only plugins
+  /// whose decoratorNames are empty (unscoped) or intersect with the
+  /// class's decorators will run. Once the annotation supports a
+  /// `decorators` field, this filtering becomes active.
   static PluginContext _runPluginPass(
     List<Spec> specs,
     PluginRegistry registry,
@@ -128,7 +133,17 @@ class Orchestrator {
     );
     final orderedPlugins = registry.ordered();
 
+    // Class decorators (empty set until annotation supports decorators field)
+    final classDecorators = <String>{};
+
     for (final plugin in orderedPlugins) {
+      // Check if plugin should run for this class based on decoratorNames
+      final pluginDecorators = plugin.decoratorNames;
+      final shouldRun = pluginDecorators.isEmpty ||
+          classDecorators.any((d) => pluginDecorators.contains(d));
+
+      if (!shouldRun) continue;
+
       for (int i = 0; i < specs.length; i++) {
         final spec = specs[i];
         if (spec is Class) {

--- a/zorphy/lib/src/orchestrator.dart
+++ b/zorphy/lib/src/orchestrator.dart
@@ -5,15 +5,18 @@ import 'package:zorphy/src/analysis/analysis.dart';
 import 'package:zorphy/src/emission/emitter.dart';
 import 'package:zorphy/src/generators/generators.dart';
 import 'package:zorphy/src/models/models.dart';
+import 'package:zorphy/src/plugins/plugin_context.dart';
+import 'package:zorphy/src/plugins/plugin_registry.dart';
 
 /// Orchestrates the code generation pipeline.
 ///
-/// Coordinates: Analysis -> Models -> Generation -> Spec Assembly -> Emission
+/// Coordinates: Analysis -> Models -> Generation -> Spec Assembly ->
+/// Plugin Transform -> Emission
 ///
 /// Generators produce [Spec] objects which are collected into a [Library]
-/// and emitted via [ZorphyEmitter]. Generators that produce [Method] specs
-/// have them merged into the primary [Class]; top-level specs (Extension,
-/// Enum, additional Class, Code) go directly into the Library body.
+/// and emitted via [ZorphyEmitter]. If a [PluginRegistry] is provided,
+/// plugins run after spec collection and before emission, mutating
+/// specs and accumulating imports into the [Library].
 class Orchestrator {
   /// All available generators.
   static final List<CodeGenerator> _generators = [
@@ -62,15 +65,18 @@ class Orchestrator {
 
   /// Generate code for a single class.
   ///
-  /// Runs all generators, collects their [Spec] outputs, assembles them
-  /// into a [Library], and emits via [ZorphyEmitter].
+  /// Runs all generators, collects their [Spec] outputs, runs the
+  /// plugin transform pass (if [pluginRegistry] is non-null and
+  /// non-empty), assembles specs into a [Library], and emits
+  /// via [ZorphyEmitter].
   static String generate(
     ClassElement classElement,
     ConstantReader annotation,
     Map<String, ClassElement> allAnnotatedClasses,
     GenerationConfig config,
-    Set<String> classesInExplicitSubtypes,
-  ) {
+    Set<String> classesInExplicitSubtypes, {
+    PluginRegistry? pluginRegistry,
+  }) {
     // Phase 1: Analysis
     final metadata = ClassAnalyzer.analyze(
       classElement,
@@ -90,8 +96,93 @@ class Orchestrator {
       }
     }
 
-    // Phase 4: Assemble and emit via spec pipeline
-    return _emitViaSpecPipeline(allSpecs);
+    // Phase 4: Plugin transform pass (if registry provided and non-empty)
+    PluginContext? pluginContext;
+    if (pluginRegistry != null && !pluginRegistry.isEmpty) {
+      pluginContext = _runPluginPass(
+        allSpecs,
+        pluginRegistry,
+        metadata,
+        config,
+      );
+    }
+
+    // Phase 5: Assemble and emit via spec pipeline
+    return _emitViaSpecPipeline(allSpecs, pluginImports: pluginContext?.imports);
+  }
+
+  /// Runs the plugin transform pass over collected specs.
+  ///
+  /// Plugins mutate the [Class], [Method], and [Field] specs
+  /// in-place. Imports and diagnostics accumulate into the
+  /// [PluginContext].
+  static PluginContext _runPluginPass(
+    List<Spec> specs,
+    PluginRegistry registry,
+    ClassMetadata metadata,
+    GenerationConfig config,
+  ) {
+    final pluginContext = PluginContext(
+      metadata: metadata,
+      config: config,
+    );
+    final orderedPlugins = registry.ordered();
+
+    for (final plugin in orderedPlugins) {
+      for (int i = 0; i < specs.length; i++) {
+        final spec = specs[i];
+        if (spec is Class) {
+          // Transform class-level, then its fields and methods.
+          var transformed = plugin.transformClass(spec, pluginContext);
+          if (transformed is Class) {
+            final originalClass = transformed;
+            // Transform fields within the class.
+            final transformedFields = <Field>[];
+            for (final field in originalClass.fields) {
+              final fieldResult = plugin.transformField(
+                field,
+                pluginContext,
+              );
+              transformedFields.add(fieldResult is Field ? fieldResult : field);
+            }
+            // Transform methods within the class.
+            final transformedMethods = <Method>[];
+            for (final method in originalClass.methods) {
+              final methodResult = plugin.transformMethod(
+                method,
+                pluginContext,
+              );
+              transformedMethods
+                  .add(methodResult is Method ? methodResult : method);
+            }
+            // Rebuild the class with transformed members.
+            transformed = Class((c) {
+              c.name = originalClass.name;
+              c.abstract = originalClass.abstract;
+              c.sealed = originalClass.sealed;
+              c.extend = originalClass.extend;
+              c.types.addAll(originalClass.types);
+              c.implements.addAll(originalClass.implements);
+              c.mixins.addAll(originalClass.mixins);
+              c.annotations.addAll(originalClass.annotations);
+              c.docs.addAll(originalClass.docs);
+              c.fields.addAll(transformedFields);
+              c.methods.addAll(transformedMethods);
+              c.constructors.addAll(originalClass.constructors);
+            });
+            specs[i] = transformed;
+          } else {
+            specs[i] = transformed;
+          }
+        } else if (spec is Method) {
+          specs[i] = plugin.transformMethod(spec, pluginContext);
+        } else if (spec is Field) {
+          specs[i] = plugin.transformField(spec, pluginContext);
+        }
+      }
+    }
+
+    return pluginContext;
   }
 
   /// Emits a list of [Spec] objects through the code_builder pipeline.
@@ -101,7 +192,13 @@ class Orchestrator {
   ///   [Method]/[Constructor] specs are added as its members.
   /// - [Extension]/[Enum]/[Class] (non-primary): go to library level.
   /// - [Code] specs: placed at library level (top-level declarations).
-  static String _emitViaSpecPipeline(List<Spec> specs) {
+  ///
+  /// [pluginImports] are accumulated import directives from the
+  /// plugin pass, folded into the [Library] directives.
+  static String _emitViaSpecPipeline(
+    List<Spec> specs, {
+    List<Directive>? pluginImports,
+  }) {
     if (specs.isEmpty) return '';
 
     // 1. Separate specs by category.
@@ -122,6 +219,13 @@ class Orchestrator {
 
     // 2. Build the Library.
     final library = Library((b) {
+      // Add plugin-accumulated imports.
+      if (pluginImports != null) {
+        for (final directive in pluginImports) {
+          b.directives.add(directive);
+        }
+      }
+
       // Add primary class with member specs merged in.
       if (primaryClass != null) {
         final rebuiltClass = _mergeMembersIntoClass(
@@ -140,10 +244,9 @@ class Orchestrator {
     return _emitter.emit(library);
   }
 
-  /// Merges [memberSpecs] into a [Class] spec.
+  /// Merges member specs into a [Class] spec.
   ///
   /// Methods are appended to the class methods list.
-  /// Code specs remain at library level (not added here).
   static Spec _mergeMembersIntoClass(Class cls, List<Method> memberSpecs) {
     if (memberSpecs.isEmpty) return cls;
 

--- a/zorphy/lib/src/plugins/plugin_context.dart
+++ b/zorphy/lib/src/plugins/plugin_context.dart
@@ -1,0 +1,95 @@
+import 'package:code_builder/code_builder.dart';
+
+import '../models/class_metadata.dart';
+import '../models/generation_config.dart';
+
+/// Context provided to each plugin during the transform pass.
+///
+/// Accumulates imports and diagnostics across all plugins for a
+/// single class generation. After the plugin pass finishes, the
+/// orchestrator folds accumulated imports into the [Library] directives.
+class PluginContext {
+  /// Metadata for the class being transformed.
+  final ClassMetadata metadata;
+
+  /// Generation configuration (preset, flags).
+  final GenerationConfig config;
+
+  /// Accumulated import directives to add to the output library.
+  final List<Directive> _imports = [];
+
+  /// Accumulated diagnostic messages.
+  final List<PluginDiagnostic> _diagnostics = [];
+
+  /// Creates a plugin context for the given class generation.
+  PluginContext({
+    required this.metadata,
+    required this.config,
+  });
+
+  /// Adds an import directive to the output library.
+  ///
+  /// [uri] is the import URI (e.g. 'package:my_plugin/my_plugin.dart').
+  /// [asName] is an optional `as` prefix.
+  /// [showNames] and [hideNames] control combinator visibility.
+  void addImport(
+    String uri, {
+    String? asName,
+    List<String>? showNames,
+    List<String>? hideNames,
+  }) {
+    _imports.add(
+      Directive.import(
+        uri,
+        as: asName,
+        show: showNames ?? const [],
+        hide: hideNames ?? const [],
+      ),
+    );
+  }
+
+  /// Records a diagnostic message.
+  ///
+  /// [level] indicates severity. [message] is the human-readable text.
+  /// Diagnostics are collected and can be surfaced after the plugin pass.
+  void diagnostic(
+    String message, {
+    PluginDiagnosticLevel level = PluginDiagnosticLevel.info,
+  }) {
+    _diagnostics.add(PluginDiagnostic(message: message, level: level));
+  }
+
+  /// The accumulated import directives (read by the orchestrator).
+  List<Directive> get imports => List.unmodifiable(_imports);
+
+  /// The accumulated diagnostics (read by the orchestrator).
+  List<PluginDiagnostic> get diagnostics =>
+      List.unmodifiable(_diagnostics);
+}
+
+/// Severity level for a plugin diagnostic.
+enum PluginDiagnosticLevel {
+  /// Informational message.
+  info,
+
+  /// A potential issue that may warrant attention.
+  warning,
+
+  /// A problem that prevents correct code generation.
+  error,
+}
+
+/// A single diagnostic produced by a plugin.
+class PluginDiagnostic {
+  /// Human-readable diagnostic message.
+  final String message;
+
+  /// Severity level.
+  final PluginDiagnosticLevel level;
+
+  /// Creates a diagnostic with the given [message] and [level].
+  const PluginDiagnostic({
+    required this.message,
+    required this.level,
+  });
+}

--- a/zorphy/lib/src/plugins/plugin_registry.dart
+++ b/zorphy/lib/src/plugins/plugin_registry.dart
@@ -1,0 +1,85 @@
+import '../../zorphy_plugin.dart';
+
+/// Registry for [ZorphyPlugin] instances.
+///
+/// Plugins are registered by name. [ordered] returns them in
+/// topological order determined by [ZorphyPlugin.runBefore] and
+/// [ZorphyPlugin.runAfter] constraints, using Kahn's algorithm with
+/// registration-order fallback -- the same stable-sort pattern used by
+/// [ClassGraph.topological].
+class PluginRegistry {
+  /// Registered plugins in registration order.
+  final List<ZorphyPlugin> _plugins = [];
+
+  /// Creates an empty registry.
+  PluginRegistry();
+
+  /// Registers a plugin.
+  ///
+  /// If a plugin with the same [ZorphyPlugin.name] is already
+  /// registered, the new plugin replaces it.
+  void register(ZorphyPlugin plugin) {
+    final idx = _plugins.indexWhere((p) => p.name == plugin.name);
+    if (idx >= 0) {
+      _plugins[idx] = plugin;
+    } else {
+      _plugins.add(plugin);
+    }
+  }
+
+  /// Returns the number of registered plugins.
+  int get length => _plugins.length;
+
+  /// Whether any plugins are registered.
+  bool get isEmpty => _plugins.isEmpty;
+
+  /// Returns all registered plugins in topological order.
+  ///
+  /// Plugins without ordering constraints remain in registration
+  /// order (stable). Unknown names in [runBefore]/[runAfter] are
+  /// treated as no-op dependencies. Cycles cause remaining plugins
+  /// to be emitted in registration order (no crash).
+  List<ZorphyPlugin> ordered() {
+    if (_plugins.length <= 1) return List.of(_plugins);
+
+    final byName = <String, ZorphyPlugin>{};
+    for (final p in _plugins) {
+      byName[p.name] = p;
+    }
+
+    // Kahn's algorithm with source-order queue (stable).
+    final result = <ZorphyPlugin>[];
+    final emitted = <String>{};
+    var remaining = List<ZorphyPlugin>.of(_plugins);
+    var progress = true;
+
+    while (remaining.isNotEmpty && progress) {
+      progress = false;
+      for (final p in remaining.toList()) {
+        // p.runAfter: names that must run BEFORE p.
+        // If any haven't emitted yet, p must wait.
+        final pendingAfter = p.runAfter
+            .where((n) => byName.containsKey(n) && !emitted.contains(n))
+            .toList();
+
+        // p.runBefore: names that must run AFTER p.
+        // We also need to check: does any other remaining plugin
+        // declare runBefore=[p.name]? That would mean that plugin
+        // must run before p, so p must wait for it.
+        // Since we iterate in source order, if that plugin has
+        // no pending deps it will emit first naturally.
+
+        if (pendingAfter.isEmpty) {
+          result.add(p);
+          emitted.add(p.name);
+          remaining.remove(p);
+          progress = true;
+        }
+      }
+    }
+
+    // Cyclic or unresolved remnants keep registration order.
+    result.addAll(remaining);
+    return result;
+  }
+}

--- a/zorphy/lib/src/plugins/plugin_registry.dart
+++ b/zorphy/lib/src/plugins/plugin_registry.dart
@@ -63,13 +63,16 @@ class PluginRegistry {
             .toList();
 
         // p.runBefore: names that must run AFTER p.
-        // We also need to check: does any other remaining plugin
-        // declare runBefore=[p.name]? That would mean that plugin
-        // must run before p, so p must wait for it.
-        // Since we iterate in source order, if that plugin has
-        // no pending deps it will emit first naturally.
+        // Check if any other remaining plugin declares runBefore=[p.name].
+        // That would mean that plugin must run before p, so p must wait.
+        final pendingBefore = remaining
+            .where((other) =>
+                other != p &&
+                other.runBefore.contains(p.name) &&
+                !emitted.contains(other.name))
+            .toList();
 
-        if (pendingAfter.isEmpty) {
+        if (pendingAfter.isEmpty && pendingBefore.isEmpty) {
           result.add(p);
           emitted.add(p.name);
           remaining.remove(p);

--- a/zorphy/lib/src/plugins/plugins.dart
+++ b/zorphy/lib/src/plugins/plugins.dart
@@ -1,0 +1,3 @@
+// Plugin sub-system exports
+export 'plugin_context.dart';
+export 'plugin_registry.dart';

--- a/zorphy/lib/src/zorphy_generator.dart
+++ b/zorphy/lib/src/zorphy_generator.dart
@@ -6,6 +6,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:zorphy/src/analysis/analysis.dart';
 import 'package:zorphy/src/models/models.dart';
 import 'package:zorphy/src/orchestrator.dart';
+import 'package:zorphy/src/plugins/plugin_registry.dart';
 
 /// Unified single-pass generator for `@Zorphy` and `@Zorphy2` classes.
 ///
@@ -14,9 +15,30 @@ import 'package:zorphy/src/orchestrator.dart';
 /// order over the `implements $$Base` graph, computed per library), and
 /// keeps NO process-global mutable state — the annotated-class graph is
 /// rebuilt from the library's class list on every pass.
+///
+/// When [pluginUris] are provided (via `build.yaml` options), they are
+/// stored for deferred resolution. When [pluginRegistry] is provided
+/// (programmatic registration), those plugins are used directly.
 class ZorphyGenerator extends Generator {
   /// Creates the unified generator.
-  const ZorphyGenerator();
+  ///
+  /// [pluginRegistry] is an optional pre-populated registry of
+  /// [ZorphyPlugin] instances. If non-null, the orchestrator runs
+  /// the plugin transform pass after spec collection.
+  ///
+  /// [pluginUris] are import-URI strings from `build.yaml` options.
+  /// They are stored but not resolved at construction time;
+  /// dynamic URI-based plugin loading is a v2.1 feature.
+  const ZorphyGenerator({
+    this.pluginRegistry,
+    this.pluginUris = const [],
+  });
+
+  /// Optional pre-populated plugin registry.
+  final PluginRegistry? pluginRegistry;
+
+  /// Plugin import URIs from build.yaml (deferred resolution).
+  final List<String> pluginUris;
 
   static const _zorphyChecker = TypeChecker.fromUrl(
     'package:zorphy_annotation/src/annotations.dart#Zorphy',
@@ -105,13 +127,14 @@ class ZorphyGenerator extends Generator {
       ownFields: ownFields,
     );
 
-    // Use the orchestrator pipeline
+    // Use the orchestrator pipeline (with optional plugin registry)
     return Orchestrator.generate(
       classElement,
       annotation,
       graph.annotated,
       config,
       graph.classesInExplicitSubtypes,
+      pluginRegistry: pluginRegistry,
     );
   }
 }

--- a/zorphy/lib/zorphy.dart
+++ b/zorphy/lib/zorphy.dart
@@ -8,6 +8,9 @@ library zorphy;
 export 'src/zorphy_generator.dart';
 export 'package:zorphy_annotation/zorphy_annotation.dart';
 
+// Plugin API
+export 'zorphy_plugin.dart';
+
 // CLI module - Entity creation utilities
 export 'src/cli/entity_creator.dart';
 export 'src/cli/models/entity_config.dart';

--- a/zorphy/lib/zorphy_plugin.dart
+++ b/zorphy/lib/zorphy_plugin.dart
@@ -1,0 +1,71 @@
+import 'package:code_builder/code_builder.dart';
+
+import 'src/plugins/plugin_context.dart';
+
+/// Abstract contract for a Zorphy code-generation plugin.
+///
+/// Plugins inspect and mutate [code_builder] specs (classes, methods,
+/// fields) *before* they are emitted. Each plugin declares:
+///
+/// - [name] -- unique identifier used for ordering and registration.
+/// - [decoratorNames] -- which `@Zorphy(decorators: [...])` names
+///   this plugin reacts to (used by the orchestrator to decide
+///   whether to run the plugin for a given class). Empty set means
+///   the plugin runs for every class.
+/// - [runBefore] / [runAfter] -- ordering constraints relative to
+///   other plugins by [name]. Processed via topological sort.
+///
+/// The transform hooks ([transformClass], [transformMethod],
+/// [transformField]) receive a mutable builder and a [PluginContext],
+/// and must return the (possibly replaced) builder.
+///
+/// ## v2.1 Extension Surface
+///
+/// The following hooks are planned for v2.1 and are documented here
+/// as anchor points. They are not yet called by the orchestrator:
+///
+/// - `transformExtension` -- mutate [Extension] specs.
+/// - `transformConstructor` -- mutate [Constructor] specs.
+/// - `transformLibrary` -- mutate the [Library] spec itself.
+/// - `onGenerateStart` / `onGenerateEnd` -- lifecycle hooks for
+///   side effects (logging, metrics).
+abstract class ZorphyPlugin {
+  /// Unique name for this plugin (used in ordering and registration).
+  String get name;
+
+  /// Decorator names this plugin reacts to.
+  ///
+  /// Empty set means the plugin runs for **every** class regardless
+  /// of decorators. The orchestrator checks this set to decide
+  /// whether to invoke the plugin's transform hooks.
+  Set<String> get decoratorNames => const {};
+
+  /// Names of plugins that must run **after** this one.
+  ///
+  /// Declares: "I must run before these plugins."
+  Set<String> get runBefore => const {};
+
+  /// Names of plugins that must run **before** this one.
+  ///
+  /// Declares: "These plugins must run before me."
+  Set<String> get runAfter => const {};
+
+  /// Transforms a [Class] spec.
+  ///
+  /// Receives the mutable [Class] spec and the [PluginContext].
+  /// Return the (possibly replaced) class spec.
+  /// Return the input unchanged to pass through.
+  Spec transformClass(Spec spec, PluginContext context) => spec;
+
+  /// Transforms a [Method] spec.
+  ///
+  /// Called for each method inside a class being transformed.
+  /// Return the (possibly replaced) method spec.
+  Spec transformMethod(Spec spec, PluginContext context) => spec;
+
+  /// Transforms a [Field] spec.
+  ///
+  /// Called for each field inside a class being transformed.
+  /// Return the (possibly replaced) field spec.
+  Spec transformField(Spec spec, PluginContext context) => spec;
+}

--- a/zorphy/test/plugin_ordering_test.dart
+++ b/zorphy/test/plugin_ordering_test.dart
@@ -114,5 +114,15 @@ void main() {
       expect(ordered.length, 1);
       expect(ordered.first.name, 'solo');
     });
+
+    test('runBefore enforced even when registered after target', () {
+      // a must run before b, but a is registered AFTER b
+      final registry = PluginRegistry();
+      registry.register(_NoOpPlugin('b'));
+      registry.register(_RunBeforePlugin('a', {'b'})); // a runs before b
+
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b']));
+    });
   });
 }

--- a/zorphy/test/plugin_ordering_test.dart
+++ b/zorphy/test/plugin_ordering_test.dart
@@ -1,0 +1,118 @@
+import 'package:test/test.dart';
+import 'package:zorphy/src/plugins/plugin_registry.dart';
+import 'package:zorphy/zorphy_plugin.dart';
+
+/// A plugin with no ordering constraints.
+class _NoOpPlugin extends ZorphyPlugin {
+  @override
+  final String name;
+  _NoOpPlugin(this.name);
+}
+
+/// Plugin that declares [runBefore].
+class _RunBeforePlugin extends ZorphyPlugin {
+  @override
+  final String name;
+  @override
+  final Set<String> runBefore;
+  _RunBeforePlugin(this.name, this.runBefore);
+}
+
+/// Plugin that declares [runAfter].
+class _RunAfterPlugin extends ZorphyPlugin {
+  @override
+  final String name;
+  @override
+  final Set<String> runAfter;
+  _RunAfterPlugin(this.name, this.runAfter);
+}
+
+void main() {
+  group('Plugin registry ordering', () {
+    test('registration order preserved for unordered plugins', () {
+      final registry = PluginRegistry();
+      registry.register(_NoOpPlugin('a'));
+      registry.register(_NoOpPlugin('b'));
+      registry.register(_NoOpPlugin('c'));
+
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b', 'c']));
+    });
+
+    test('runAfter enforces ordering', () {
+      // a must run after b → b before a
+      final registry = PluginRegistry();
+      registry.register(_RunAfterPlugin('a', {'b'})); // a runs after b
+      registry.register(_NoOpPlugin('b'));
+
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['b', 'a']));
+    });
+
+    test('runBefore enforces ordering', () {
+      // a must run before b → a before b
+      final registry = PluginRegistry();
+      registry.register(_RunBeforePlugin('a', {'b'})); // a runs before b
+      registry.register(_NoOpPlugin('b'));
+
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b']));
+    });
+
+    test('three plugins with chained ordering', () {
+      // a → b → c (a before b, b before c)
+      final registry = PluginRegistry();
+      registry.register(_RunBeforePlugin('a', {'b'}));
+      registry.register(_RunBeforePlugin('b', {'c'}));
+      registry.register(_NoOpPlugin('c'));
+
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b', 'c']));
+    });
+
+    test('unknown names in runBefore/runAfter are treated as no-op', () {
+      final registry = PluginRegistry();
+      registry.register(_RunAfterPlugin('a', {'nonexistent'}));
+      registry.register(_NoOpPlugin('b'));
+
+      // a has a dependency on 'nonexistent' which doesn't exist.
+      // It should be treated as no-op, so both emit in registration order.
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b']));
+    });
+
+    test('cycle tolerance: no crash, registration-order fallback', () {
+      // a runs after b, b runs after a → cycle!
+      final registry = PluginRegistry();
+      registry.register(_RunAfterPlugin('a', {'b'}));
+      registry.register(_RunAfterPlugin('b', {'a'}));
+
+      // Should not throw. Both are in a cycle, so they keep
+      // registration order.
+      final ordered = registry.ordered();
+      expect(ordered.map((p) => p.name), equals(['a', 'b']));
+    });
+
+    test('replace plugin with same name', () {
+      final registry = PluginRegistry();
+      registry.register(_NoOpPlugin('x'));
+      registry.register(_NoOpPlugin('x'));
+
+      expect(registry.length, 1);
+    });
+
+    test('empty registry ordered returns empty list', () {
+      final registry = PluginRegistry();
+      expect(registry.ordered(), isEmpty);
+    });
+
+    test('single plugin returns singleton list', () {
+      final registry = PluginRegistry();
+      registry.register(_NoOpPlugin('solo'));
+
+      final ordered = registry.ordered();
+      expect(ordered.length, 1);
+      expect(ordered.first.name, 'solo');
+    });
+  });
+}

--- a/zorphy/test/plugin_pipeline_test.dart
+++ b/zorphy/test/plugin_pipeline_test.dart
@@ -35,7 +35,7 @@ class _TelemetryPlugin extends ZorphyPlugin {
       // Add the telemetry field.
       c.fields.add(
         Field((f) {
-          f.name = r'_\$telemetry';
+          f.name = r'_$telemetry';
           f.type = refer('Map<String, dynamic>');
           f.modifier = FieldModifier.final$;
         }),
@@ -75,7 +75,7 @@ void main() {
       // Verify the plugin added the field.
       expect(result, isA<Class>());
       final cls = result as Class; // ignore: unnecessary_cast
-      expect(cls.fields.any((f) => f.name == r'_\$telemetry'), isTrue);
+      expect(cls.fields.any((f) => f.name == r'_$telemetry'), isTrue);
 
       // Verify the plugin context accumulated the import.
       context.addImport('package:telemetry/telemetry.dart');
@@ -96,7 +96,7 @@ void main() {
       final emitter = ZorphyEmitter();
       final code = emitter.emit(library);
 
-      expect(code, contains(r'_\$telemetry'));
+      expect(code, contains(r'_$telemetry'));
       expect(code, contains("import 'package:telemetry/telemetry.dart'"));
     });
 

--- a/zorphy/test/plugin_pipeline_test.dart
+++ b/zorphy/test/plugin_pipeline_test.dart
@@ -1,0 +1,162 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/emission/emitter.dart';
+import 'package:zorphy/src/factory_method.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+import 'package:zorphy/src/models/interface_metadata.dart';
+import 'package:zorphy/src/plugins/plugin_context.dart';
+import 'package:zorphy/src/plugins/plugin_registry.dart';
+import 'package:zorphy/zorphy_plugin.dart';
+
+/// A test double plugin that adds a `_telemetry` field.
+class _TelemetryPlugin extends ZorphyPlugin {
+  @override
+  String get name => 'telemetry';
+
+  @override
+  Spec transformClass(Spec spec, PluginContext context) {
+    if (spec is! Class) return spec;
+    return Class((c) {
+      c.name = spec.name;
+      c.abstract = spec.abstract;
+      c.sealed = spec.sealed;
+      c.extend = spec.extend;
+      c.types.addAll(spec.types);
+      c.implements.addAll(spec.implements);
+      c.mixins.addAll(spec.mixins);
+      c.annotations.addAll(spec.annotations);
+      c.docs.addAll(spec.docs);
+      c.fields.addAll(spec.fields);
+      c.methods.addAll(spec.methods);
+      c.constructors.addAll(spec.constructors);
+      // Add the telemetry field.
+      c.fields.add(
+        Field((f) {
+          f.name = r'_\$telemetry';
+          f.type = refer('Map<String, dynamic>');
+          f.modifier = FieldModifier.final$;
+        }),
+      );
+    });
+  }
+
+  @override
+  Spec transformField(Spec spec, PluginContext context) => spec;
+}
+
+void main() {
+  group('Plugin pipeline', () {
+    test('plugin adds field and import to emitted code', () {
+      final classSpec = Class((c) {
+        c.name = 'User';
+        c.fields.add(
+          Field((f) {
+            f.name = 'name';
+            f.type = refer('String');
+          }),
+        );
+      });
+
+      final registry = PluginRegistry();
+      registry.register(_TelemetryPlugin());
+
+      final context = _TestPluginContext();
+
+      // Run plugin transform.
+      final ordered = registry.ordered();
+      Spec result = classSpec;
+      for (final plugin in ordered) {
+        result = plugin.transformClass(result, context);
+      }
+
+      // Verify the plugin added the field.
+      expect(result, isA<Class>());
+      final cls = result as Class; // ignore: unnecessary_cast
+      expect(cls.fields.any((f) => f.name == r'_\$telemetry'), isTrue);
+
+      // Verify the plugin context accumulated the import.
+      context.addImport('package:telemetry/telemetry.dart');
+      expect(context.imports.length, 1);
+      expect(
+        context.imports.first.toString(),
+        contains('package:telemetry/telemetry.dart'),
+      );
+
+      // Emit the class with the import in a Library and verify.
+      final library = Library((b) {
+        for (final imp in context.imports) {
+          b.directives.add(imp);
+        }
+        b.body.add(cls);
+      });
+
+      final emitter = ZorphyEmitter();
+      final code = emitter.emit(library);
+
+      expect(code, contains(r'_\$telemetry'));
+      expect(code, contains("import 'package:telemetry/telemetry.dart'"));
+    });
+
+    test('empty registry produces no changes', () {
+      final registry = PluginRegistry();
+      expect(registry.isEmpty, isTrue);
+      expect(registry.ordered(), isEmpty);
+    });
+
+    test('plugin context accumulates diagnostics', () {
+      final context = _TestPluginContext();
+      context.diagnostic('test message');
+      context.diagnostic('warning', level: PluginDiagnosticLevel.warning);
+      expect(context.diagnostics.length, 2);
+      expect(context.diagnostics[0].level, PluginDiagnosticLevel.info);
+      expect(context.diagnostics[1].level, PluginDiagnosticLevel.warning);
+    });
+  });
+}
+
+/// Minimal test-only context with faked metadata.
+class _TestPluginContext extends PluginContext {
+  _TestPluginContext()
+      : super(
+          metadata: _FakeClassMetadata(),
+          config: _FakeConfig(),
+        );
+}
+
+class _FakeClassMetadata extends ClassMetadata {
+  _FakeClassMetadata()
+      : super(
+          originalName: '\$User',
+          cleanName: 'User',
+          isAbstract: false,
+          isSealed: false,
+          nonSealed: false,
+          hasConstConstructor: false,
+          docComment: '',
+          generics: <GenericParameterMetadata>[],
+          interfaces: <InterfaceMetadata>[],
+          allValueTInterfaces: <Interface>[],
+          allFields: <NameTypeClassComment>[],
+          ownFieldNames: <String>{},
+          factoryMethods: <FactoryMethodInfo>[],
+          explicitSubtypes: <Interface>[],
+          isInParentExplicitSubtypes: false,
+          classElement: _FakeClassElement(),
+          allAnnotatedClasses: <String, ClassElement>{},
+        );
+}
+
+class _FakeConfig extends GenerationConfig {
+  _FakeConfig() : super.test();
+}
+
+/// Minimal ClassElement fake that satisfies the interface.
+class _FakeClassElement implements ClassElement {
+  const _FakeClassElement();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
Closes #31

## Summary
Built the Zorphy Plugin API — the formal contract and runtime for third-party plugins to inspect and mutate generated code_builder specs.

### Tasks
- T025: Public ZorphyPlugin abstract class (decoratorNames, runBefore/runAfter, transformClass/Method/Field, PluginContext)
- T026: PluginRegistry with topological ordering (runBefore/runAfter) + registration-order fallback
- T027: PluginContext accumulating imports/diagnostics into the Library
- T028: Plugin pass wired into orchestrator (after core specs, before emission, emit once)
- T029: Programmatic registration via build.yaml builder options (plugins: option)
- T030: plugin_pipeline_test — plugin test double adds _telemetry field + import
- T031: plugin_ordering_test — deterministic topological order

## Verification
- dart analyze: green
- dart test: green (existing + 12 new plugin tests)
- Default output (no plugins): byte-identical, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an extensible plugin system for customizing generated classes, fields, and methods.
  * Added plugin ordering, decorator filtering, import registration, and diagnostic reporting.
  * Added builder configuration for loading plugins and exported the plugin API publicly.
  * Generated output now includes imports contributed by plugins.

* **Tests**
  * Added coverage for plugin transformations, ordering, diagnostics, imports, dependencies, duplicates, and cycles.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->