### PR TITLE
docs: plugin API documentation & example

### DIFF
--- a/website/docs/plugins.mdx
+++ b/website/docs/plugins.mdx
@@ -1,6 +1,6 @@
 # Plugin API
 
-Zorphy 2.0 introduces a **Plugin API** that lets third-party code inspect and mutate the generated `code_builder` specs before they are emitted. This is the foundation of the Extensible Compiler Pipeline (Pillar 2) that powers Zuraffa v6's Decorator-Driven Architecture.
+Zorphy 2.0 introduces a **Plugin API** that lets third-party code inspect and mutate the generated `code_builder` specs before they are emitted. This is the foundation of the Extensible Compiler Pipeline.
 
 ## How It Works
 
@@ -42,31 +42,15 @@ class TimestampPlugin extends ZorphyPlugin {
   Spec transformClass(Spec spec, PluginContext context) {
     if (spec is! Class) return spec;
 
-    // Add an import that the generated code will need.
-    context.addImport('package:my_package/timestamp.dart');
-
     // Rebuild the class with an additional field.
-    return Class((c) {
-      c.name = spec.name;
-      c.abstract = spec.abstract;
-      c.sealed = spec.sealed;
-      c.extend = spec.extend;
-      c.types.addAll(spec.types);
-      c.implements.addAll(spec.implements);
-      c.mixins.addAll(spec.mixins);
-      c.annotations.addAll(spec.annotations);
-      c.docs.addAll(spec.docs);
-      c.fields.addAll(spec.fields);
-      c.methods.addAll(spec.methods);
-      c.constructors.addAll(spec.constructors);
-      c.fields.add(
+    return spec.rebuild((c) => c
+      ..fields.add(
         Field((f) {
           f.name = 'generatedAt';
           f.type = refer('DateTime');
           f.modifier = FieldModifier.final$;
         }),
-      );
-    });
+      ));
   }
 }
 ```
@@ -111,7 +95,7 @@ registry.register(PluginA()); // runBefore: {'B'}
 registry.register(PluginB()); // runBefore: {'C'}
 registry.register(PluginC());
 
-print(registry.ordered().map((p) => p.name));
+print(registry.ordered().map((p) => p.name).toList());
 // [A, B, C]
 ```
 
@@ -138,7 +122,7 @@ The builder reads the `plugins` list and passes the URIs to `ZorphyGenerator`. W
 For tests or custom pipelines, register plugins directly:
 
 ```dart
-import 'package:zorphy/src/plugins/plugin_registry.dart';
+import 'package:zorphy/zorphy_plugin.dart';
 
 final registry = PluginRegistry();
 registry.register(TimestampPlugin());

--- a/website/docs/plugins.mdx
+++ b/website/docs/plugins.mdx
@@ -1,0 +1,161 @@
+# Plugin API
+
+Zorphy 2.0 introduces a **Plugin API** that lets third-party code inspect and mutate the generated `code_builder` specs before they are emitted. This is the foundation of the Extensible Compiler Pipeline (Pillar 2) that powers Zuraffa v6's Decorator-Driven Architecture.
+
+## How It Works
+
+The code generation pipeline runs in these phases:
+
+1. **Analysis** — `ClassAnalyzer` produces `ClassMetadata` from the annotated element.
+2. **Generation** — Built-in generators produce `Spec` objects (Class, Method, Extension, etc.).
+3. **Plugin Transform** *(new)* — Registered plugins mutate the specs in topological order.
+4. **Emission** — The mutated specs are assembled into a `Library` and emitted once via `ZorphyEmitter`.
+
+```
+┌──────────┐    ┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│ Analysis  │───>│  Generation  │───>│Plugin Pass   │───>│   Emission   │
+└──────────┘    └──────────────┘    └──────────────┘    └──────────────┘
+                                      │
+                              ┌───────┴────────┐
+                              │ Plugin A       │
+                              │ Plugin B       │
+                              │ Plugin C       │
+                              └────────────────┘
+```
+
+## Writing a Plugin
+
+Extend `ZorphyPlugin` and implement one or more transform hooks:
+
+```dart
+import 'package:code_builder/code_builder.dart';
+import 'package:zorphy/zorphy_plugin.dart';
+
+class TimestampPlugin extends ZorphyPlugin {
+  @override
+  String get name => 'timestamp';
+
+  @override
+  Set<String> get runAfter => const {'logging'};
+
+  @override
+  Spec transformClass(Spec spec, PluginContext context) {
+    if (spec is! Class) return spec;
+
+    // Add an import that the generated code will need.
+    context.addImport('package:my_package/timestamp.dart');
+
+    // Rebuild the class with an additional field.
+    return Class((c) {
+      c.name = spec.name;
+      c.abstract = spec.abstract;
+      c.sealed = spec.sealed;
+      c.extend = spec.extend;
+      c.types.addAll(spec.types);
+      c.implements.addAll(spec.implements);
+      c.mixins.addAll(spec.mixins);
+      c.annotations.addAll(spec.annotations);
+      c.docs.addAll(spec.docs);
+      c.fields.addAll(spec.fields);
+      c.methods.addAll(spec.methods);
+      c.constructors.addAll(spec.constructors);
+      c.fields.add(
+        Field((f) {
+          f.name = 'generatedAt';
+          f.type = refer('DateTime');
+          f.modifier = FieldModifier.final$;
+        }),
+      );
+    });
+  }
+}
+```
+
+## Plugin Contract
+
+### `ZorphyPlugin`
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `name` | `String` | Unique identifier for ordering and registration. |
+| `decoratorNames` | `Set<String>` | Which decorator names this plugin reacts to. Empty = runs for every class. |
+| `runBefore` | `Set<String>` | Plugin names that must run **after** this one. |
+| `runAfter` | `Set<String>` | Plugin names that must run **before** this one. |
+| `transformClass` | `Spec` Function | Mutate a `Class` spec. Return the (possibly replaced) spec. |
+| `transformMethod` | `Spec` Function | Mutate a `Method` spec. Called for each method in a class. |
+| `transformField` | `Spec` Function | Mutate a `Field` spec. Called for each field in a class. |
+
+All transform hooks have pass-through defaults — override only the ones you need.
+
+### `PluginContext`
+
+Passed to every transform hook. Provides:
+
+| Method | Description |
+|--------|-------------|
+| `addImport(uri, {asName, showNames, hideNames})` | Add an import directive to the output library. |
+| `diagnostic(message, {level})` | Record a diagnostic (info / warning / error). |
+| `imports` | Read accumulated import directives. |
+| `diagnostics` | Read accumulated diagnostics. |
+| `metadata` | The `ClassMetadata` for the class being transformed. |
+| `config` | The `GenerationConfig` (preset, flags). |
+
+## Plugin Ordering
+
+Plugins are executed in **topological order** determined by `runBefore` / `runAfter` constraints, using Kahn's algorithm with registration-order fallback for unordered plugins.
+
+```dart
+// A runs before B, B runs before C.
+final registry = PluginRegistry();
+registry.register(PluginA()); // runBefore: {'B'}
+registry.register(PluginB()); // runBefore: {'C'}
+registry.register(PluginC());
+
+print(registry.ordered().map((p) => p.name));
+// [A, B, C]
+```
+
+Unknown names in `runBefore`/`runAfter` are treated as no-ops. Cycles do not crash — remaining plugins emit in registration order.
+
+## Registration via `build.yaml`
+
+Add plugin URIs to the builder options:
+
+```yaml
+targets:
+  $default:
+    builders:
+      zorphy:zorphy:
+        options:
+          plugins:
+            - package:my_plugin/my_plugin.dart
+```
+
+The builder reads the `plugins` list and passes the URIs to `ZorphyGenerator`. When no `plugins` option is present, output is byte-identical to the pre-plugin pipeline — **zero regressions**.
+
+## Programmatic Registration
+
+For tests or custom pipelines, register plugins directly:
+
+```dart
+import 'package:zorphy/src/plugins/plugin_registry.dart';
+
+final registry = PluginRegistry();
+registry.register(TimestampPlugin());
+
+// Pass to ZorphyGenerator:
+final generator = ZorphyGenerator(pluginRegistry: registry);
+```
+
+## v2.1 Extension Surface
+
+The following hooks are planned for v2.1 and are documented in `ZorphyPlugin`'s doc comments as anchor points:
+
+- `transformExtension` — mutate `Extension` specs
+- `transformConstructor` — mutate `Constructor` specs
+- `transformLibrary` — mutate the `Library` spec itself
+- `onGenerateStart` / `onGenerateEnd` — lifecycle hooks for side effects (logging, metrics)
+
+## Example
+
+See [`example/lib/plugin_example.dart`](https://github.com/arrrrny/zorphy/blob/development/zorphy/example/lib/plugin_example.dart) for a compilable no-op plugin that demonstrates the full contract.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -12,6 +12,11 @@ const sidebars = {
     },
     {
       type: 'doc',
+      id: 'plugins',
+      label: 'Plugin API'
+    },
+    {
+      type: 'doc',
       id: 'vs-freezed',
       label: 'Zorphy vs Freezed'
     },

--- a/zorphy/README.md
+++ b/zorphy/README.md
@@ -28,6 +28,7 @@
 - 🔄 **ChangeTo** - Convert between related types in inheritance hierarchies
 - 🤖 **AI-Friendly CLI** - Command-line tool optimized for AI agents and developers
 - 🔌 **MCP Server** - Model Context Protocol server for agentic integration
+- 🔮 **Plugin API** - Extensible compiler pipeline with third-party plugin support
 
 ## 📦 Installation
 
@@ -312,6 +313,73 @@ Field name (or press Enter to finish):
   - name: String
   - age: int
 ```
+
+## 🔮 Plugin API
+
+Zorphy 2.0 supports third-party plugins that can inspect and mutate generated code before it is emitted. Plugins are Dart classes that extend `ZorphyPlugin` and implement transform hooks for classes, methods, and fields.
+
+**Quick example** — a plugin that adds a timestamp field:
+
+```dart
+import 'package:code_builder/code_builder.dart';
+import 'package:zorphy/zorphy_plugin.dart';
+
+class TimestampPlugin extends ZorphyPlugin {
+  @override
+  String get name => 'timestamp';
+
+  @override
+  Spec transformClass(Spec spec, PluginContext context) {
+    if (spec is! Class) return spec;
+    context.addImport('package:my_package/timestamp.dart');
+    return Class((c) {
+      c.name = spec.name;
+      c.abstract = spec.abstract;
+      c.sealed = spec.sealed;
+      c.extend = spec.extend;
+      c.types.addAll(spec.types);
+      c.implements.addAll(spec.implements);
+      c.mixins.addAll(spec.mixins);
+      c.annotations.addAll(spec.annotations);
+      c.docs.addAll(spec.docs);
+      c.fields.addAll(spec.fields);
+      c.methods.addAll(spec.methods);
+      c.constructors.addAll(spec.constructors);
+      c.fields.add(Field((f) {
+        f.name = 'generatedAt';
+        f.type = refer('DateTime');
+        f.modifier = FieldModifier.final$;
+      }));
+    });
+  }
+}
+```
+
+**Register via `build.yaml`:**
+
+```yaml
+targets:
+  $default:
+    builders:
+      zorphy:zorphy:
+        options:
+          plugins:
+            - package:my_package/timestamp_plugin.dart
+```
+
+**Programmatic registration:**
+
+```dart
+import 'package:zorphy/src/plugins/plugin_registry.dart';
+
+final registry = PluginRegistry();
+registry.register(TimestampPlugin());
+final generator = ZorphyGenerator(pluginRegistry: registry);
+```
+
+Plugins execute in topological order via `runBefore`/`runAfter` constraints. When no plugins are registered, output is byte-identical to the pre-plugin pipeline.
+
+📚 **[Full Plugin API docs](https://arrrrny.github.io/zorphy/docs/plugins)** · [Example](./example/lib/plugin_example.dart)
 
 ## 🔌 Zorphy MCP Server
 

--- a/zorphy/README.md
+++ b/zorphy/README.md
@@ -36,10 +36,10 @@ Add the dependencies to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zorphy_annotation: ^1.7.0
+  zorphy_annotation: ^2.0.0
 
 dev_dependencies:
-  zorphy: ^1.7.0
+  zorphy: ^2.0.0
   build_runner: ^2.4.0
 ```
 
@@ -331,26 +331,14 @@ class TimestampPlugin extends ZorphyPlugin {
   @override
   Spec transformClass(Spec spec, PluginContext context) {
     if (spec is! Class) return spec;
-    context.addImport('package:my_package/timestamp.dart');
-    return Class((c) {
-      c.name = spec.name;
-      c.abstract = spec.abstract;
-      c.sealed = spec.sealed;
-      c.extend = spec.extend;
-      c.types.addAll(spec.types);
-      c.implements.addAll(spec.implements);
-      c.mixins.addAll(spec.mixins);
-      c.annotations.addAll(spec.annotations);
-      c.docs.addAll(spec.docs);
-      c.fields.addAll(spec.fields);
-      c.methods.addAll(spec.methods);
-      c.constructors.addAll(spec.constructors);
-      c.fields.add(Field((f) {
-        f.name = 'generatedAt';
-        f.type = refer('DateTime');
-        f.modifier = FieldModifier.final$;
-      }));
-    });
+    return spec.rebuild((c) => c
+      ..methods.add(Method((m) {
+        m.name = 'generatedAt';
+        m.type = MethodType.getter;
+        m.returns = refer('DateTime');
+        m.lambda = true;
+        m.body = refer('DateTime').property('now').call([]).code;
+      })));
   }
 }
 ```
@@ -370,7 +358,7 @@ targets:
 **Programmatic registration:**
 
 ```dart
-import 'package:zorphy/src/plugins/plugin_registry.dart';
+import 'package:zorphy/zorphy_plugin.dart';
 
 final registry = PluginRegistry();
 registry.register(TimestampPlugin());

--- a/zorphy/example/lib/plugin_example.dart
+++ b/zorphy/example/lib/plugin_example.dart
@@ -1,9 +1,8 @@
 /// Example demonstrating how to write and register a Zorphy plugin.
 ///
 /// This file defines a no-op plugin (`LoggingPlugin`) that logs every
-/// class it transforms and adds an import. It compiles with
-/// `dart analyze` and shows the registration pattern you would use
-/// in your own projects.
+/// class it transforms. It compiles with `dart analyze` and shows the
+/// registration pattern you would use in your own projects.
 ///
 /// To activate this plugin, add it to your `build.yaml`:
 ///
@@ -14,7 +13,7 @@
 ///       zorphy:zorphy:
 ///         options:
 ///           plugins:
-///             - example/lib/plugin_example.dart
+///             - package:your_package/your_plugin.dart
 /// ```
 
 import 'package:code_builder/code_builder.dart';
@@ -48,11 +47,11 @@ class LoggingPlugin extends ZorphyPlugin {
   Spec transformField(Spec spec, PluginContext context) => spec;
 }
 
-/// A plugin that adds a `createdAt` timestamp field to every class.
+/// A plugin that adds a `generatedAt` timestamp field to every class.
 ///
 /// Demonstrates:
 /// - Adding a field via [transformClass]
-/// - Adding an import via [PluginContext.addImport]
+/// - Using spec.rebuild to preserve all class properties
 class TimestampPlugin extends ZorphyPlugin {
   @override
   String get name => 'timestamp';
@@ -65,31 +64,15 @@ class TimestampPlugin extends ZorphyPlugin {
   Spec transformClass(Spec spec, PluginContext context) {
     if (spec is! Class) return spec;
 
-    // Add the import needed for the field type.
-    context.addImport('package:zorphy_example/timestamp.dart');
-
     // Rebuild the class with an additional field.
-    return Class((c) {
-      c.name = spec.name;
-      c.abstract = spec.abstract;
-      c.sealed = spec.sealed;
-      c.extend = spec.extend;
-      c.types.addAll(spec.types);
-      c.implements.addAll(spec.implements);
-      c.mixins.addAll(spec.mixins);
-      c.annotations.addAll(spec.annotations);
-      c.docs.addAll(spec.docs);
-      c.fields.addAll(spec.fields);
-      c.methods.addAll(spec.methods);
-      c.constructors.addAll(spec.constructors);
-      c.fields.add(
+    return spec.rebuild((c) => c
+      ..fields.add(
         Field((f) {
           f.name = 'generatedAt';
           f.type = refer('DateTime');
           f.modifier = FieldModifier.final$;
         }),
-      );
-    });
+      ));
   }
 
   @override
@@ -107,7 +90,7 @@ class TimestampPlugin extends ZorphyPlugin {
 /// registry directly:
 ///
 /// ```dart
-/// import 'package:zorphy/src/plugins/plugin_registry.dart';
+/// import 'package:zorphy/zorphy_plugin.dart';
 ///
 /// final registry = PluginRegistry();
 /// registry.register(LoggingPlugin());
@@ -116,5 +99,5 @@ class TimestampPlugin extends ZorphyPlugin {
 /// // Plugins execute in topological order:
 /// // 'logging' runs first, then 'timestamp'.
 /// final ordered = registry.ordered();
-/// print(ordered.map((p) => p.name)); // [logging, timestamp]
+/// print(ordered.map((p) => p.name).toList()); // [logging, timestamp]
 /// ```

--- a/zorphy/example/lib/plugin_example.dart
+++ b/zorphy/example/lib/plugin_example.dart
@@ -1,0 +1,120 @@
+/// Example demonstrating how to write and register a Zorphy plugin.
+///
+/// This file defines a no-op plugin (`LoggingPlugin`) that logs every
+/// class it transforms and adds an import. It compiles with
+/// `dart analyze` and shows the registration pattern you would use
+/// in your own projects.
+///
+/// To activate this plugin, add it to your `build.yaml`:
+///
+/// ```yaml
+/// targets:
+///   $default:
+///     builders:
+///       zorphy:zorphy:
+///         options:
+///           plugins:
+///             - example/lib/plugin_example.dart
+/// ```
+
+import 'package:code_builder/code_builder.dart';
+import 'package:zorphy/zorphy_plugin.dart';
+
+/// A minimal no-op plugin that demonstrates the ZorphyPlugin contract.
+///
+/// This plugin:
+/// - Runs for every class (empty [decoratorNames] = universal)
+/// - Logs the class name via [PluginContext.diagnostic]
+/// - Does not mutate any specs (passes them through unchanged)
+class LoggingPlugin extends ZorphyPlugin {
+  @override
+  String get name => 'logging';
+
+  @override
+  Set<String> get decoratorNames => const {};
+
+  @override
+  Spec transformClass(Spec spec, PluginContext context) {
+    if (spec is Class) {
+      context.diagnostic('LoggingPlugin: transforming ${spec.name}');
+    }
+    return spec; // no-op: return unchanged
+  }
+
+  @override
+  Spec transformMethod(Spec spec, PluginContext context) => spec;
+
+  @override
+  Spec transformField(Spec spec, PluginContext context) => spec;
+}
+
+/// A plugin that adds a `createdAt` timestamp field to every class.
+///
+/// Demonstrates:
+/// - Adding a field via [transformClass]
+/// - Adding an import via [PluginContext.addImport]
+class TimestampPlugin extends ZorphyPlugin {
+  @override
+  String get name => 'timestamp';
+
+  /// This plugin must run after 'logging' (if both are registered).
+  @override
+  Set<String> get runAfter => const {'logging'};
+
+  @override
+  Spec transformClass(Spec spec, PluginContext context) {
+    if (spec is! Class) return spec;
+
+    // Add the import needed for the field type.
+    context.addImport('package:zorphy_example/timestamp.dart');
+
+    // Rebuild the class with an additional field.
+    return Class((c) {
+      c.name = spec.name;
+      c.abstract = spec.abstract;
+      c.sealed = spec.sealed;
+      c.extend = spec.extend;
+      c.types.addAll(spec.types);
+      c.implements.addAll(spec.implements);
+      c.mixins.addAll(spec.mixins);
+      c.annotations.addAll(spec.annotations);
+      c.docs.addAll(spec.docs);
+      c.fields.addAll(spec.fields);
+      c.methods.addAll(spec.methods);
+      c.constructors.addAll(spec.constructors);
+      c.fields.add(
+        Field((f) {
+          f.name = 'generatedAt';
+          f.type = refer('DateTime');
+          f.modifier = FieldModifier.final$;
+        }),
+      );
+    });
+  }
+
+  @override
+  Spec transformMethod(Spec spec, PluginContext context) => spec;
+
+  @override
+  Spec transformField(Spec spec, PluginContext context) => spec;
+}
+
+/// Programmatic registration example.
+///
+/// When using the builder system, plugins are resolved from
+/// `build.yaml` options automatically. For programmatic use
+/// (e.g. in tests or custom build pipelines), instantiate the
+/// registry directly:
+///
+/// ```dart
+/// import 'package:zorphy/src/plugins/plugin_registry.dart';
+///
+/// final registry = PluginRegistry();
+/// registry.register(LoggingPlugin());
+/// registry.register(TimestampPlugin());
+///
+/// // Plugins execute in topological order:
+/// // 'logging' runs first, then 'timestamp'.
+/// final ordered = registry.ordered();
+/// print(ordered.map((p) => p.name)); // [logging, timestamp]
+/// ```

--- a/zorphy/lib/zorphy.dart
+++ b/zorphy/lib/zorphy.dart
@@ -10,6 +10,7 @@ export 'package:zorphy_annotation/zorphy_annotation.dart';
 
 // Plugin API
 export 'zorphy_plugin.dart';
+export 'src/plugins/plugin_context.dart';
 
 // CLI module - Entity creation utilities
 export 'src/cli/entity_creator.dart';

--- a/zorphy/lib/zorphy_plugin.dart
+++ b/zorphy/lib/zorphy_plugin.dart
@@ -3,6 +3,7 @@ import 'package:code_builder/code_builder.dart';
 import 'src/plugins/plugin_context.dart';
 
 export 'src/plugins/plugin_context.dart';
+export 'src/plugins/plugin_registry.dart';
 
 /// Abstract contract for a Zorphy code-generation plugin.
 ///

--- a/zorphy/lib/zorphy_plugin.dart
+++ b/zorphy/lib/zorphy_plugin.dart
@@ -2,6 +2,8 @@ import 'package:code_builder/code_builder.dart';
 
 import 'src/plugins/plugin_context.dart';
 
+export 'src/plugins/plugin_context.dart';
+
 /// Abstract contract for a Zorphy code-generation plugin.
 ///
 /// Plugins inspect and mutate [code_builder] specs (classes, methods,


### PR DESCRIPTION
Closes #24

## Summary
Public-facing documentation for the Zorphy Plugin API.

### Tasks
- T032: website/docs/plugins.mdx — plugin contract doc with lifecycle hooks, code examples, ordering, registration
- T033: README Plugin API section linking docs + example
- T034: example/lib/plugin_example.dart — compilable no-op (LoggingPlugin) + timestamp plugin (TimestampPlugin)

### Additional fixes
- Export PluginContext from zorphy_plugin.dart (required by plugin authors)
- Add plugins.mdx to website sidebar navigation

## Acceptance Criteria
- [x] website/docs/plugins.mdx published with plugin contract, lifecycle hooks, code example
- [x] README Plugin API section links to the docs page and example
- [x] example/lib/plugin_example.dart compiles with dart analyze (zero issues)
- [x] Example demonstrates registration via build.yaml options (in docs + doc comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Zorphy Plugin API for extending class generation with transformation hooks and configurable ordering.
  * Added support for plugin registration through build configuration or programmatic setup.
  * Added a plugin context to the public library API.
  * Added example logging and timestamp plugins.

* **Documentation**
  * Added comprehensive Plugin API documentation, README guidance, configuration details, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->