### PR TITLE
chore: migrate zorphy_annotation to v2.1 + version sync

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,8 +7,16 @@ on:
     branches: [ master, main, development ]
 
 jobs:
+  version_sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check version sync
+        run: bash scripts/check_version_sync.sh
+
   analyze_and_test:
     runs-on: ubuntu-latest
+    needs: version_sync
 
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +70,7 @@ jobs:
     # Verifies zorphy resolves, analyzes, and tests green against both
     # analyzer 13.x and 14.x (published constraint: >=13.0.0 <15.0.0).
     runs-on: ubuntu-latest
+    needs: version_sync
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/check_version_sync.sh
+++ b/scripts/check_version_sync.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# check_version_sync.sh — Fails if zorphy and zorphy_annotation versions diverge.
+# Usage: ./scripts/check_version_sync.sh
+# Exit code: 0 = in sync, 1 = diverged.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+ZORPHY_VER="$(grep '^version:' "$ROOT_DIR/zorphy/pubspec.yaml" | head -1 | awk '{print $2}')"
+ZA_VER="$(grep '^version:' "$ROOT_DIR/zorphy_annotation/pubspec.yaml" | head -1 | awk '{print $2}')"
+
+if [ "$ZORPHY_VER" != "$ZA_VER" ]; then
+  echo "ERROR: version mismatch — zorphy=$ZORPHY_VER, zorphy_annotation=$ZA_VER"
+  exit 1
+fi
+
+echo "OK: both packages at version $ZORPHY_VER"

--- a/zorphy/CHANGELOG.md
+++ b/zorphy/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [2.1.0] - 2026-08-03
+
+### Feat
+
+- AST-based smart regeneration engine — non-destructive merge of
+  generated output with user edits (region markers, structural diff,
+  conflict reporting)
+- Plugin API & registry (`ZorphyPlugin`, `PluginContext`,
+  `PluginRegistry`) — post-spec transform hooks with topological
+  ordering, import injection, and diagnostic accumulation
+- `MergeMode` enum (`smart` / `force`) and `isForce` builder/
+  generator flag to bypass smart merge
+- `ZorphyPlugin` abstract class exported from `zorphy.dart`
+
+### Change
+
+- Version synced with `zorphy_annotation` 2.1.0
+- `zorphy_annotation` dependency bumped to `^2.1.0`
+
 ## [2.0.0] - 2026-07-30
 
 ### Break

--- a/zorphy/lib/src/merge/merge_types.dart
+++ b/zorphy/lib/src/merge/merge_types.dart
@@ -2,14 +2,9 @@
 ///
 /// Defines the data structures used by the merge engine.
 
-/// How the merge engine should operate.
-enum MergeMode {
-  /// Parse existing file, merge intelligently (default).
-  smart,
-
-  /// Overwrite the entire file (current build_runner behavior).
-  force,
-}
+// Re-export canonical MergeMode from zorphy_annotation to ensure
+// type identity between annotation consumers and the merge engine.
+export 'package:zorphy_annotation/src/merge_mode.dart' show MergeMode;
 
 /// The kind of change a [DiffEntry] represents.
 enum DiffType { added, removed, modified, unchanged }

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -1,13 +1,13 @@
 name: zorphy
 description: A powerful code generation package for Dart/Flutter that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  zorphy_annotation: ^2.0.0
+  zorphy_annotation: ^2.1.0
   analyzer: ">=13.0.0 <15.0.0"
   build: ^4.0.4
   source_gen: ^4.2.3

--- a/zorphy_annotation/CHANGELOG.md
+++ b/zorphy_annotation/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.1.0] - 2026-08-03
+
+### Feat
+
+- Added `MergeMode` enum (`smart` / `force`) for future per-class merge
+  control — re-exported from `zorphy_annotation.dart` for consumer access
+
+### Change
+
+- SDK constraint aligned to `>=3.8.0 <4.0.0` (matches `zorphy` package)
+- Version synced with `zorphy` 2.1.0
+
 ## [2.0.0] - 2026-07-30
 
 ### Break

--- a/zorphy_annotation/lib/src/merge_mode.dart
+++ b/zorphy_annotation/lib/src/merge_mode.dart
@@ -1,0 +1,16 @@
+/// Controls how zorphy regenerates output files.
+///
+/// - [smart]: Parse existing file, merge intelligently (default).
+///   Preserves user edits in non-generated regions.
+/// - [force]: Overwrite the entire file (legacy build_runner behavior).
+///
+/// This enum is re-exported from `zorphy_annotation` for use in
+/// annotation parameters (e.g. future per-class merge control).
+/// The canonical definition lives in `zorphy`'s merge engine.
+enum MergeMode {
+  /// Parse existing file, merge intelligently (default).
+  smart,
+
+  /// Overwrite the entire file (current build_runner behavior).
+  force,
+}

--- a/zorphy_annotation/lib/src/merge_mode.dart
+++ b/zorphy_annotation/lib/src/merge_mode.dart
@@ -2,11 +2,10 @@
 ///
 /// - [smart]: Parse existing file, merge intelligently (default).
 ///   Preserves user edits in non-generated regions.
-/// - [force]: Overwrite the entire file (legacy build_runner behavior).
+/// - [force]: Overwrite the entire file (current build_runner behavior).
 ///
-/// This enum is re-exported from `zorphy_annotation` for use in
-/// annotation parameters (e.g. future per-class merge control).
-/// The canonical definition lives in `zorphy`'s merge engine.
+/// This is the canonical MergeMode definition used by both the annotation
+/// package and zorphy's merge engine (MergeOrchestrator).
 enum MergeMode {
   /// Parse existing file, merge intelligently (default).
   smart,

--- a/zorphy_annotation/lib/zorphy_annotation.dart
+++ b/zorphy_annotation/lib/zorphy_annotation.dart
@@ -22,4 +22,5 @@ library zorphy_annotation;
 
 // Export all annotations
 export 'zorphy.dart';
+export 'src/merge_mode.dart';
 export 'src/patch_base.dart';

--- a/zorphy_annotation/pubspec.yaml
+++ b/zorphy_annotation/pubspec.yaml
@@ -1,10 +1,10 @@
 name: zorphy_annotation
 description: Annotations for zorphy code generation package that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   collection: ^1.19.1


### PR DESCRIPTION
Closes #42

## Summary

Audits `zorphy_annotation` against v2.1 changes and brings it in lockstep with `zorphy`.

### Changes
- Add `MergeMode` enum (`smart` / `force`) to `zorphy_annotation`, exported from `zorphy_annotation.dart`
- Bump both `zorphy` and `zorphy_annotation` to **2.1.0**
- Align `zorphy_annotation` SDK constraint to `>=3.8.0 <4.0.0` (matches `zorphy`)
- Update `zorphy` dep on `zorphy_annotation` to `^2.1.0`
- Add `scripts/check_version_sync.sh` — fails if versions diverge
- Update both CHANGELOGs

### Pre-existing failures (not from this PR)
- 2 fixture tests need build_runner
- merge module missing declaration_scanner.dart (PR #41)

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge controls with smart and force modes for generated files.
  * Exposed the new merge options through the annotation package.

* **Documentation**
  * Added version 2.1.0 changelog entries documenting regeneration, plugin, merge, and generation features.

* **Chores**
  * Updated both packages to version 2.1.0.
  * Raised the minimum Dart SDK requirement to 3.8.0.
  * Added a check to verify package versions remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->