### PR TITLE
fix: add missing declaration_scanner.dart and resolve merge module errors

### DIFF
--- a/zorphy/lib/src/merge/declaration_scanner.dart
+++ b/zorphy/lib/src/merge/declaration_scanner.dart
@@ -1,0 +1,193 @@
+/// Lightweight top-level declaration scanner for Dart source.
+///
+/// Uses regex-based pattern matching (no analyzer dependency) to extract
+/// top-level declarations (classes, extensions, enums, mixins, functions)
+/// and their line ranges. Sufficient for zorphy's generated files where
+/// the structure is predictable.
+
+/// A top-level declaration extracted from Dart source.
+class Declaration {
+  /// The kind of declaration (e.g. 'class', 'extension', 'enum', 'mixin',
+  /// 'function', 'typedef').
+  final String kind;
+
+  /// The declaration name.
+  final String name;
+
+  /// Zero-based start line (inclusive).
+  final int startLine;
+
+  /// Zero-based end line (exclusive, for use with `List.sublist`).
+  final int endLine;
+
+  const Declaration({
+    required this.kind,
+    required this.name,
+    required this.startLine,
+    required this.endLine,
+  });
+
+  @override
+  String toString() => '$kind $name (lines $startLine..$endLine)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is Declaration &&
+          other.kind == kind &&
+          other.name == name &&
+          other.startLine == startLine &&
+          other.endLine == endLine;
+
+  @override
+  int get hashCode => Object.hash(kind, name, startLine, endLine);
+}
+
+/// Pattern for top-level declarations we care about.
+///
+/// Matches:
+/// - `(abstract |sealed )?class Name`
+/// - `extension Name`
+/// - `enum Name`
+/// - `mixin Name`
+/// - `typedef Name`
+/// - top-level `FutureOr<T> name(` or `T name(` functions
+final _declPattern = RegExp(
+  r'^(?:abstract\s+|sealed\s+)?'
+  r'(class|extension|enum|mixin|typedef)\s+'
+  r'(\$?[A-Za-z_][A-Za-z0-9_\$]*)',
+);
+
+/// Pattern for top-level function declarations (simplified).
+/// Matches lines like `String doSomething(` or `void main(` at column 0.
+final _functionPattern = RegExp(
+  r'^(?:[A-Za-z_<][A-Za-z0-9_<>?,\s]*\s+)?'
+  r'([A-Za-z_][A-Za-z0-9_]*)\s*\(',
+);
+
+/// Extract top-level declarations from [source].
+///
+/// Returns a list of [Declaration] with their line ranges.
+/// Brace-depth tracking determines the end of each declaration.
+List<Declaration> extractDeclarationsFromSource(String source) {
+  final lines = source.split('\n');
+  final declarations = <Declaration>[];
+
+  // Keywords that signal a declaration we should skip (part, import,
+  // export, etc.).
+  const skipPrefixes = [
+    'import ', 'export ', 'part ', '//', '///', '/*', '* ',
+    '@', 'const ', 'final ', 'var ', 'late ',
+  ];
+
+  int i = 0;
+  while (i < lines.length) {
+    final line = lines[i];
+    final trimmed = line.trimLeft();
+
+    // Skip non-declaration lines.
+    if (trimmed.isEmpty || skipPrefixes.any((p) => trimmed.startsWith(p))) {
+      i++;
+      continue;
+    }
+
+    // Try class/extension/enum/mixin/typedef.
+    final declMatch = _declPattern.firstMatch(trimmed);
+    if (declMatch != null) {
+      final kind = declMatch.group(1)!;
+      final name = declMatch.group(2)!;
+      final endLine = _findDeclarationEnd(lines, i);
+      declarations.add(Declaration(
+        kind: kind,
+        name: name,
+        startLine: i,
+        endLine: endLine,
+      ));
+      i = endLine;
+      continue;
+    }
+
+    // Try top-level function.
+    final funcMatch = _functionPattern.firstMatch(trimmed);
+    if (funcMatch != null && _looksLikeFunction(lines, i)) {
+      final name = funcMatch.group(1)!;
+      // Skip known Dart keywords that aren't function names.
+      if (const ['if', 'for', 'while', 'switch', 'catch', 'on'].contains(name)) {
+        i++;
+        continue;
+      }
+      final endLine = _findDeclarationEnd(lines, i);
+      declarations.add(Declaration(
+        kind: 'function',
+        name: name,
+        startLine: i,
+        endLine: endLine,
+      ));
+      i = endLine;
+      continue;
+    }
+
+    i++;
+  }
+
+  return declarations;
+}
+
+/// Walk forward from [startLine] tracking brace depth to find where
+/// the declaration ends. Returns the line index **after** the closing
+/// brace (exclusive, for use with `List.sublist`).
+///
+/// If no opening brace is found, returns [startLine + 1] (single-line
+/// declaration).
+int _findDeclarationEnd(List<String> lines, int startLine) {
+  int depth = 0;
+  bool foundOpen = false;
+
+  for (int i = startLine; i < lines.length; i++) {
+    for (final ch in lines[i].runes) {
+      if (ch == 0x7B) { // '{'
+        depth++;
+        foundOpen = true;
+      } else if (ch == 0x7D) { // '}'
+        depth--;
+      }
+    }
+    if (foundOpen && depth <= 0) {
+      // Return the line after the closing brace.
+      return i + 1;
+    }
+  }
+
+  // Unterminated brace — return end of file.
+  return lines.length;
+}
+
+/// Heuristic: check whether line at [lineIndex] looks like a top-level
+/// function definition (not a method call, assignment, etc.).
+bool _looksLikeFunction(List<String> lines, int lineIndex) {
+  final trimmed = lines[lineIndex].trim();
+
+  // Must contain '(' — functions have parameter lists.
+  if (!trimmed.contains('(')) return false;
+
+  // Must NOT start with return/throw/await/yield — those are statements.
+  if (const ['return ', 'return;', 'throw ', 'throw;', 'await ', 'yield ']
+      .any((p) => trimmed.startsWith(p))) {
+    return false;
+  }
+
+  // Must NOT be an assignment (contains '=' before '(').
+  final parenIdx = trimmed.indexOf('(');
+  final eqIdx = trimmed.indexOf('=');
+  if (eqIdx >= 0 && eqIdx < parenIdx) return false;
+
+  // Should NOT be a function call (starts with lowercase and has
+  // no return type). Real top-level functions typically have a type.
+  if (parenIdx > 0 &&
+      trimmed.substring(0, parenIdx).trim().split(' ').length < 2) {
+    // Only one word before '(' — likely a call, not a definition.
+    // Exception: constructors and operators.
+    return false;
+  }
+
+  return true;
+}

--- a/zorphy/lib/src/merge/declaration_scanner.dart
+++ b/zorphy/lib/src/merge/declaration_scanner.dart
@@ -45,14 +45,14 @@ class Declaration {
 /// Pattern for top-level declarations we care about.
 ///
 /// Matches:
-/// - `(abstract |sealed )?class Name`
+/// - `(abstract |sealed |final |base |interface )?class Name`
 /// - `extension Name`
 /// - `enum Name`
 /// - `mixin Name`
 /// - `typedef Name`
 /// - top-level `FutureOr<T> name(` or `T name(` functions
 final _declPattern = RegExp(
-  r'^(?:abstract\s+|sealed\s+)?'
+  r'^(?:abstract\s+|sealed\s+|final\s+|base\s+|interface\s+)?'
   r'(class|extension|enum|mixin|typedef)\s+'
   r'(\$?[A-Za-z_][A-Za-z0-9_\$]*)',
 );
@@ -84,13 +84,15 @@ List<Declaration> extractDeclarationsFromSource(String source) {
     final line = lines[i];
     final trimmed = line.trimLeft();
 
-    // Skip non-declaration lines.
-    if (trimmed.isEmpty || skipPrefixes.any((p) => trimmed.startsWith(p))) {
+    // Skip empty lines.
+    if (trimmed.isEmpty) {
       i++;
       continue;
     }
 
-    // Try class/extension/enum/mixin/typedef.
+    // Try class/extension/enum/mixin/typedef BEFORE applying skipPrefixes,
+    // so that modifier-prefixed declarations (e.g. "final class Foo") are
+    // properly recognized.
     final declMatch = _declPattern.firstMatch(trimmed);
     if (declMatch != null) {
       final kind = declMatch.group(1)!;
@@ -103,6 +105,12 @@ List<Declaration> extractDeclarationsFromSource(String source) {
         endLine: endLine,
       ));
       i = endLine;
+      continue;
+    }
+
+    // Skip non-declaration lines (imports, comments, top-level variables).
+    if (skipPrefixes.any((p) => trimmed.startsWith(p))) {
+      i++;
       continue;
     }
 
@@ -136,8 +144,11 @@ List<Declaration> extractDeclarationsFromSource(String source) {
 /// the declaration ends. Returns the line index **after** the closing
 /// brace (exclusive, for use with `List.sublist`).
 ///
-/// If no opening brace is found, returns [startLine + 1] (single-line
-/// declaration).
+/// For brace-less declarations (e.g. typedefs), returns [startLine + 1]
+/// when a semicolon is encountered before any opening brace.
+///
+/// **Limitation:** Does not ignore braces inside string literals or comments,
+/// so unusual constructs may confuse the scanner.
 int _findDeclarationEnd(List<String> lines, int startLine) {
   int depth = 0;
   bool foundOpen = false;
@@ -149,6 +160,9 @@ int _findDeclarationEnd(List<String> lines, int startLine) {
         foundOpen = true;
       } else if (ch == 0x7D) { // '}'
         depth--;
+      } else if (ch == 0x3B && !foundOpen) { // ';' before any '{'
+        // Brace-less declaration (e.g. typedef) — end after this line.
+        return i + 1;
       }
     }
     if (foundOpen && depth <= 0) {
@@ -157,7 +171,7 @@ int _findDeclarationEnd(List<String> lines, int startLine) {
     }
   }
 
-  // Unterminated brace — return end of file.
+  // Unterminated brace or declaration — return end of file.
   return lines.length;
 }
 

--- a/zorphy/lib/src/merge/merge_orchestrator.dart
+++ b/zorphy/lib/src/merge/merge_orchestrator.dart
@@ -88,7 +88,6 @@ class MergeOrchestrator {
     }
 
     final existingLines = existingContent.split('\n');
-    final generatedLines = generatedContent.split('\n');
 
     final existingDecls = extractDeclarationsFromSource(existingContent);
     final generatedDecls = extractDeclarationsFromSource(generatedContent);

--- a/zorphy/lib/src/merge/merge_strategy.dart
+++ b/zorphy/lib/src/merge/merge_strategy.dart
@@ -141,16 +141,38 @@ class MergeStrategy {
 
   /// Try to find the replacement content in the generated source
   /// for a given existing generated region.
+  ///
+  /// When the generated content contains `// GENERATED` / `// END GENERATED`
+  /// markers, returns the full generated block (markers included) so the
+  /// output preserves the marker structure.
+  /// Otherwise falls back to declaration-level matching.
   static String? _findGeneratedReplacement({
     required SourceRegion existingRegion,
     required String generatedContent,
   }) {
-    // Extract declaration names from the existing region.
+    final generatedLines = generatedContent.split('\n');
+
+    // If the generated content has GENERATED markers, use the full
+    // block (including markers) as the replacement.
+    final genStartIdx = generatedLines.indexWhere(
+      (l) => l.trim().startsWith('// GENERATED'),
+    );
+    final genEndIdx = generatedLines.lastIndexWhere(
+      (l) => l.trim().startsWith('// END GENERATED'),
+    );
+
+    if (genStartIdx >= 0 && genEndIdx > genStartIdx) {
+      return generatedLines
+          .sublist(genStartIdx, genEndIdx + 1)
+          .join('\n');
+    }
+
+    // Fallback: match declarations by name.
     final regionContent = existingRegion.content;
     final declNames = <String>[];
 
     final classMatch = RegExp(
-      r'(?:abstract\s+|sealed\s+)?class\s+(\$?[A-Za-z_][A-Za-z0-9_$]*)',
+      r'(?:abstract\s+|sealed\s+)?class\s+(\$?[A-Za-z_][A-Za-z0-9_\$]*)',
     ).firstMatch(regionContent);
     if (classMatch != null) {
       declNames.add(classMatch.group(1)!);
@@ -172,8 +194,6 @@ class MergeStrategy {
 
     if (declNames.isEmpty) return null;
 
-    // Find matching declarations in the generated content.
-    final generatedLines = generatedContent.split('\n');
     final generatedDecls = extractDeclarationsFromSource(generatedContent);
     final matchingDecls = <Declaration>[];
 
@@ -205,8 +225,6 @@ class MergeStrategy {
   ) {
     if (preservedBlocks.isEmpty) return replacement;
 
-    // Append preserved blocks at the end of the replacement class
-    // (before the closing brace of the last class).
     final lines = replacement.split('\n');
 
     // Find the last closing brace at column 0 (end of class).


### PR DESCRIPTION
Closes the 10 pre-existing merge module errors from PR #41.

### Changes
- New: declaration_scanner.dart (Declaration class + extractDeclarationsFromSource)
- Fixed: merge_strategy.dart preserves GENERATED/END GENERATED markers
- Fixed: merge_orchestrator.dart unused var + truncated doc comment

### Results
- dart analyze lib/: 10 issues -> **0**
- Tests: 47 passed -> **64 passed** (merge_test.dart now loads: 17/17 green)
- Only 2 pre-existing fixture failures remain (need build_runner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved detection of Dart declarations, including classes, extensions, enums, mixins, typedefs, and top-level functions.
  - Declaration boundaries and source line ranges are now tracked for more precise merging.

- **Bug Fixes**
  - Generated code blocks marked with `// GENERATED` and `// END GENERATED` are now replaced as complete blocks.
  - Improved fallback handling when generated markers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->