### PR TITLE
fix: resolve spec-pipeline generator bugs and upgrade build_runner

### DIFF
--- a/zorphy/example/pubspec.lock
+++ b/zorphy/example/pubspec.lock
@@ -463,13 +463,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   zorphy_annotation:
     dependency: "direct main"
     description:
       path: "../../zorphy_annotation"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/lib/src/generators/class_declaration_generator.dart
+++ b/zorphy/lib/src/generators/class_declaration_generator.dart
@@ -420,12 +420,9 @@ class ClassDeclarationGenerator extends UniversalGenerator {
           .where((f) =>
               !(f.isGetterOnly && f.jsonKeyInfo?.defaultValue == null))
           .toList();
-      for (var i = 0; i < copyWithFields.length; i++) {
-        final f = copyWithFields[i];
-        final comma =
-            i == copyWithFields.length - 1 ? ';' : ',';
+      for (final f in copyWithFields) {
         copyWithInitializers.add(
-          '${f.name} = ${f.name} ?? (() { throw ArgumentError("${f.name} is required"); })()$comma',
+          '${f.name} = ${f.name} ?? (() { throw ArgumentError("${f.name} is required"); })()',
         );
       }
 

--- a/zorphy/lib/src/generators/equals_tostring_generator.dart
+++ b/zorphy/lib/src/generators/equals_tostring_generator.dart
@@ -50,7 +50,7 @@ class EqualsToStringGenerator extends ConcreteClassGenerator {
 
     return Method((m) {
       m.annotations.add(refer('override'));
-      m.name = '==';
+      m.name = 'operator ==';
       m.returns = refer('bool');
       m.requiredParameters.add(Parameter((p) {
         p.name = 'other';

--- a/zorphy/lib/src/generators/fields_class_generator.dart
+++ b/zorphy/lib/src/generators/fields_class_generator.dart
@@ -33,7 +33,7 @@ class FieldsClassGenerator extends UniversalGenerator {
       c.name = '${className}Fields';
       c.abstract = true;
       c.modifier = ClassModifier.final$;
-      c.docs.add('Field descriptors for [$className] query construction');
+      c.docs.add('/// Field descriptors for [$className] query construction');
 
       for (final g in metadata.generics) {
         c.types.add(referType(

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -45,18 +45,18 @@ packages:
     dependency: "direct main"
     description:
       name: build
-      sha256: "59f99162d27dff3620f1d21165ce802237eb4556fed563c0902403f8207a7c00"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.8"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: be46e59dcfefd6c6c7127df9f1be6c1f89219fee22ae02a923463e0f286ce652
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.2"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -559,6 +559,6 @@ packages:
       path: "../zorphy_annotation"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   meta: ">=1.17.0 <2.0.0"
 
 dev_dependencies:
-  build_runner: ^2.15.2
+  build_runner: ^2.16.0
   json_serializable: ^6.14.0
   json_annotation: ^4.12.0
   test: ^1.31.1


### PR DESCRIPTION
## Summary

Fixes three code_builder emission bugs in the spec-pipeline generators that caused 2 test failures.

### Bugs fixed

1. **equals_tostring_generator.dart** — operator == keyword missing
   - code_builder does not auto-detect operator names; method name must be set to operator == explicitly.
   - Generated code had invalid Dart syntax.

2. **fields_class_generator.dart** — doc comments emitted as raw text
   - code_builder Class.docs entries are emitted verbatim without /// prefix.
   - Added /// prefix for proper Dart doc comments.

3. **class_declaration_generator.dart** — duplicate commas in copyWith constructor
   - copyWith named-constructor initializer list appended comma/semicolon, but code_builder handles separation automatically.
   - Removed the variable and simplified the loop.

### Other change

- Upgraded dev:build_runner from 2.15.2 to 2.16.0

### Verification

- dart analyze lib/ — 0 issues
- dart test — 71/71 passed (was 64 pass / 2 fail)
- Regenerated all example fixtures via build_runner build — all valid Dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated equality operators so they compile and behave as expected.
  - Improved generated `copyWith` initializers by removing unnecessary trailing punctuation.

- **Documentation**
  - Updated generated fields-class comments to use standard Dart documentation syntax.

- **Chores**
  - Updated the development tooling version used during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->