### PR TITLE
fix: emit static const field descriptors in XxxFields (Closes #50)

### DIFF
--- a/zorphy/lib/src/generators/fields_class_generator.dart
+++ b/zorphy/lib/src/generators/fields_class_generator.dart
@@ -95,6 +95,7 @@ class FieldsClassGenerator extends UniversalGenerator {
           c.fields.add(Field((f) {
             f.name = fieldName;
             f.modifier = FieldModifier.constant;
+            f.static = true;
             f.assignment = Code("Field<$className, $fieldType>('$fieldName', _\$$fieldName)");
           }));
         }


### PR DESCRIPTION
Closes #50

## Summary

The non-generic branch of `FieldsClassGenerator` emitted field descriptors as instance `const` fields inside an `abstract final class`. Dart forbids `const` on instance fields, producing 291 `const_instance_field` analyzer errors. Because the descriptors were broken instance members, every usage site accessing them statically also failed with 19 `static_access_to_instance_member` errors and 1 `argument_type_not_assignable`.

Added `f.static = true;` to the non-generic field builder so the emitted fields are `static const`, matching the class semantics and the generic branch (which already uses static methods).

## Change

```diff
// lib/src/generators/fields_class_generator.dart, non-generic branch
 c.fields.add(Field((f) {
   f.name = fieldName;
   f.modifier = FieldModifier.constant;
+  f.static = true;
   f.assignment = Code("Field<$className, $fieldType>('$fieldName', _\$$fieldName)");
 }));
```

## Verification

- **Before**: 949 analyzer issues (291 `const_instance_field` + 19 `static_access_to_instance_member` + 1 cascading `argument_type_not_assignable`)
- **After**: 638 issues (**0** in all three categories)
- Net reduction: **311 issues** (matches 291 + 19 + 1)
- **Tests**: 69 passed, 2 failed (pre-existing `map_field_fromjson_test` failures, unrelated)
- Spot-checked `basic_example.zorphy.dart`: `static const name = Field<User, String>('name', _$name);` confirmed

## Note

The 638 remaining issues are pre-existing (issues #51-#55: nullability loss, sealed-class hierarchy, `patchWithX` mismatch, etc.) and are not addressed by this PR. The generated `.zorphy.dart` example files are gitignored locally so they do not appear in the diff, but regeneration confirms the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated generated field descriptors to use static fields, improving consistency and simplifying access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->