### PR TITLE
fix: preserve nullability in generated types (Closes #57)

### DIFF
--- a/zorphy/lib/src/ast/type_ref.dart
+++ b/zorphy/lib/src/ast/type_ref.dart
@@ -7,6 +7,14 @@ library;
 import 'package:code_builder/code_builder.dart';
 
 /// References an arbitrary Dart type by its fully-qualified or simple name.
+///
+/// Works around a code_builder 4.x bug where [TypeReference.isNullable]
+/// is silently ignored when emitting [Field] types, [Parameter] types,
+/// and method return types — the `?` suffix is always dropped.
+///
+/// The workaround: for any nullable type, the full type string
+/// (including `?`) is stored in [TypeReference.symbol] with an empty
+/// `types` list, so code_builder emits it verbatim.
 TypeReference referType(String type) {
   final isNullable = type.endsWith('?');
   final cleanType = isNullable ? type.substring(0, type.length - 1) : type;
@@ -15,16 +23,34 @@ TypeReference referType(String type) {
     final rtIndex = cleanType.lastIndexOf('>');
     final baseName = cleanType.substring(0, ltIndex);
     final typeArgsStr = cleanType.substring(ltIndex + 1, rtIndex);
+
+    if (isNullable) {
+      // Workaround: code_builder 4.x ignores isNullable when types is
+      // non-empty. Store the full type string (with ?) in symbol
+      // and leave types empty so code_builder emits it verbatim.
+      return TypeReference((t) {
+        t.symbol = type;
+      });
+    }
+
     final typeArgs = _splitTypeArgs(typeArgsStr).map(referType).toList();
     return TypeReference((t) {
       t.symbol = baseName;
       t.types.addAll(typeArgs);
-      t.isNullable = isNullable;
     });
   }
+
+  if (isNullable) {
+    // Workaround: code_builder 4.x ignores isNullable for Field and
+    // Parameter types. Store the full type string (with ?) in symbol
+    // and leave types empty so code_builder emits it verbatim.
+    return TypeReference((t) {
+      t.symbol = type;
+    });
+  }
+
   return TypeReference((t) {
     t.symbol = cleanType;
-    t.isNullable = isNullable;
   });
 }
 


### PR DESCRIPTION
Closes #57

## Summary

`code_builder` 4.x silently drops the `isNullable` flag on `TypeReference` for all contexts (Field types, Parameter types, method return types) — the `?` suffix is never emitted. This caused **all** nullable types to lose nullability in generated `.zorphy.dart` concrete classes.

Consequences:
- `Map<String, String>? get replacements;` → generated as `Map<String, String> replacements` → `json_serializable` emitted `Map<String, String>.from(v as Map)` instead of the recursive `(v as Map<String, dynamic>?)?.map(...)` → **runtime crash**: `type '_Map<String, dynamic>' is not a subtype of type 'Map<String, String>?'`
- `Locale? get locale;` → generated as `Locale locale` → `json_serializable` rejected `fromJson` returning `Locale?` for a non-nullable field

## Root Cause

`TypeReference(isNullable: true)` is ignored by code_builder's emitter for `Field`, `Parameter`, and `Method.returns`. This is a code_builder 4.x bug.

## Fix

In `lib/src/ast/type_ref.dart`, modified `referType()` to store the full type string (including `?`) directly in `TypeReference.symbol` for all nullable types, bypassing the broken `isNullable` path. Non-nullable types continue using the structured `types` list for proper generic argument handling.

**One file changed**: `lib/src/ast/type_ref.dart` (+28, -2)

## Verification

| Check | Before | After |
|-------|--------|-------|
| `dart test` | 69 pass, **2 fail** | **71 pass, 0 fail** |
| `build_runner build` | 2 `Locale?` errors | **0 errors** |
| `const_instance_field` errors | 0 (fixed by #56) | 0 |
| `static_access_to_instance_member` | 0 (fixed by #56) | 0 |
| Total example analyzer issues | 638 | 112 (pre-existing #51–#55) |

### Generated `.g.dart` (map_field_test)

Before (wrong):
```dart
replacements: $checkedConvert('replacements', (v) => Map<String, String>.from(v as Map)),
```

After (correct):
```dart
replacements: $checkedConvert('replacements',
  (v) => (v as Map<String, dynamic>?)?.map((k, e) => MapEntry(k, e as String)),
),
```

### Generated `.zorphy.dart` (initialization_params_example)

Before: `final Locale locale;` (non-nullable)

After: `final Locale? locale;` (nullable, preserves source nullability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nullable type references.
  * Nullable generic and non-generic types now consistently preserve the complete type notation, including the `?` marker.
  * Resolved inconsistencies that could affect downstream processing of nullable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->