### PR TITLE
fix: make Patch.applyTo call patchWithX positionally (Closes #59)

### DIFF
--- a/zorphy/lib/src/helpers.dart
+++ b/zorphy/lib/src/helpers.dart
@@ -227,7 +227,7 @@ String getPatchClass(
   sb.writeln();
 
   sb.writeln("  $classNameTrimmed applyTo($classNameTrimmed entity) {");
-  sb.writeln("    return entity.patchWith$classNameTrimmed(patchInput: this);");
+  sb.writeln("    return entity.patchWith$classNameTrimmed(this);");
   sb.writeln("  }");
   sb.writeln();
 

--- a/zorphy/test/generation/function_type_patch_test.dart
+++ b/zorphy/test/generation/function_type_patch_test.dart
@@ -22,4 +22,21 @@ void main() {
     expect(patchClass, isNot(contains('bool Function(Object)Patch')));
     expect(patchClass, isNot(contains('bool Function(Object)Patch()')));
   });
+
+  test(
+    'Patch.applyTo calls patchWithX positionally, not via named patchInput',
+    () {
+      final patchClass = helpers.getPatchClass(
+        [NameTypeClassComment('name', 'String', '')],
+        'User',
+        [],
+      );
+
+      // applyTo must forward the entity positionally to match the
+      // positional [X? patchInput] signature emitted by patch_generator.
+      // Regression guard for the named-vs-positional mismatch fixed in #59/#66.
+      expect(patchClass, contains('return entity.patchWithUser(this);'));
+      expect(patchClass, isNot(contains('patchInput: this')));
+    },
+  );
 }


### PR DESCRIPTION
Closes #59

Also addresses #52.

## Problem
`Patch.applyTo` called `entity.patchWithX(patchInput: this)` using named syntax, but `patch_generator.dart` emits `patchWithX` with a positional optional parameter `[X? patchInput]`. This caused 87 `UNDEFINED_NAMED_PARAMETER` errors.

(The remaining 93 `MISSING_DEFAULT_VALUE_FOR_PARAMETER` errors from this issue were already resolved by PR #65 which preserved nullability in generated types.)

## Fix
Changed the call in `helpers.dart` `getPatchClass()` from named (`patchInput: this`) to positional (`this`), matching the actual method signature.

## Verification
- `dart analyze`: 0 `MISSING_DEFAULT_VALUE_FOR_PARAMETER` or `UNDEFINED_NAMED_PARAMETER` errors
- `dart test`: all 71 tests pass, 0 failures
- Spot-checked `basic_example.zorphy.dart`: `patchWithUser([UserPatch? patchInput])` + `entity.patchWithUser(this)` ✓
