### PR TITLE
fix: strip dollar markers in generated sealed-subtype implements clause (Closes #60)

### DIFF
--- a/zorphy/lib/src/generators/class_declaration_generator.dart
+++ b/zorphy/lib/src/generators/class_declaration_generator.dart
@@ -57,7 +57,7 @@ class ClassDeclarationGenerator extends UniversalGenerator {
 
       // Implements
       for (final iface in metadata.interfaces) {
-        c.implements.add(referType(iface.interfaceName));
+        c.implements.add(referType(_trimInterfaceName(iface.interfaceName)));
       }
       for (final f in metadata.allFields) {
         c.methods.add(
@@ -166,7 +166,7 @@ class ClassDeclarationGenerator extends UniversalGenerator {
         final trimmedName = _trimInterfaceName(iface.interfaceName);
         if (trimmedName != _trimInterfaceName(extendedParent) &&
             trimmedName.isNotEmpty) {
-          c.implements.add(referType(iface.interfaceName));
+          c.implements.add(referType(_trimInterfaceName(iface.interfaceName)));
         }
       }
 


### PR DESCRIPTION
Closes #60

Also addresses #53.

## Problem
Generated sealed-subtype classes kept the `$$`/`$` marker in their `implements` clause (e.g. `class CreditCard implements $$PaymentMethod`), referencing the source-level abstract class instead of the generated sealed base. This broke the subtype relationship, causing 15 analyze errors.

## Fix
Applied `_trimInterfaceName()` to both `implements` sites in `class_declaration_generator.dart` — matching what the `extends` path already does. Now generates `class CreditCard implements PaymentMethod` correctly.

## Verification
- `dart analyze`: 0 RETURN_OF_INVALID_TYPE / LIST_ELEMENT_TYPE_NOT_ASSIGNABLE / INVALID_ASSIGNMENT errors
- `dart test`: all 72 tests pass, 0 failures
- Spot-checked: `CreditCard implements PaymentMethod`, `Circle implements Shape` — no `$$` markers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated class declarations by consistently normalizing interface names, ensuring correct implemented type references for abstract and concrete classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->