### PR TITLE
fix: preserve parameter list in generated delegating factory constructors (Closes #62)

### DIFF
--- a/zorphy/lib/src/generators/factory_method_generator.dart
+++ b/zorphy/lib/src/generators/factory_method_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 
 import '../ast/ast.dart';
+import '../factory_method.dart';
 import '../helpers.dart' as helpers;
 import 'base_generator.dart';
 
@@ -23,16 +24,7 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
       final isTrulyRecursive = factoryClass == classNameTrimmed;
       if (isTrulyRecursive) continue;
 
-      final code = helpers.generateFactoryMethod(
-        factory,
-        classNameTrimmed,
-        metadata.allFields,
-      );
-
-      // The helper produces something like:
-      //   factory ClassName.methodName(params) => bodyCode;
-      // We need to extract: name, params, body, and whether it's a lambda.
-      final spec = _parseFactoryString(code, classNameTrimmed);
+      final spec = _buildFactoryConstructor(factory, classNameTrimmed);
       if (spec != null) {
         return [ClassMemberCode.constructor(spec)];
       }
@@ -55,89 +47,64 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
     });
   }
 
-  /// Parses a factory method string into a [Constructor] spec.
-  ///
-  /// Expects format: `factory ClassName.name(...) => expr;` or
-  /// `factory ClassName.name(...) { ... }`
-  static Constructor? _parseFactoryString(
-      String code, String className) {
-    // Strip leading whitespace
-    final trimmed = code.trim();
-    if (!trimmed.startsWith('factory ')) return null;
+  /// Builds a [Constructor] directly from structured [FactoryMethodInfo],
+  /// avoiding a string round-trip that previously dropped parameters.
+  static Constructor? _buildFactoryConstructor(
+    FactoryMethodInfo factory,
+    String classNameTrimmed,
+  ) {
+    // Determine body
+    final useAbstractFactoryCall = factory.bodyCode.trim().isEmpty;
+    String bodyCode;
 
-    // Find the opening paren
-    final parenIndex = trimmed.indexOf('(');
-    if (parenIndex == -1) return null;
-
-    // Extract name (between 'factory ' and '(')
-    final namePart = trimmed.substring(7, parenIndex).trim();
-    // namePart is like 'ClassName.methodName' — we just need the method name
-    final dotIndex = namePart.indexOf('.');
-    final name = dotIndex != -1
-        ? namePart.substring(dotIndex + 1)
-        : namePart;
-
-    // Find matching closing paren
-    var depth = 0;
-    var closeParenIndex = -1;
-    for (var i = parenIndex; i < trimmed.length; i++) {
-      if (trimmed[i] == '(') {
-        depth++;
-      } else if (trimmed[i] == ')') {
-        depth--;
-        if (depth == 0) {
-          closeParenIndex = i;
-          break;
-        }
-      }
-    }
-    if (closeParenIndex == -1) return null;
-
-    // Check if it's a lambda (=>) or block body ({})
-    final afterParen = trimmed.substring(closeParenIndex + 1).trim();
-    final isLambda = afterParen.startsWith('=>');
-
-    if (isLambda) {
-      // => expression;
-      final bodyCode = afterParen.substring(2).trim();
-      if (bodyCode.endsWith(';')) {
-        final inner = bodyCode.substring(0, bodyCode.length - 1).trim();
-        return Constructor((c) {
-          c.factory = true;
-          c.name = name;
-          c.lambda = true;
-          c.body = Code(inner);
-        });
-      }
+    if (useAbstractFactoryCall) {
+      // Static method delegated to abstract class
+      final callArgs = factory.parameters
+          .map((p) => '${p.name}: ${p.name}')
+          .join(', ');
+      bodyCode = '${factory.className}.${factory.name}($callArgs)';
     } else {
-      // Block body: { ... }
-      if (afterParen.startsWith('{')) {
-        // Find matching close brace
-        depth = 0;
-        var closeBraceIndex = -1;
-        for (var i = closeParenIndex + 1; i < trimmed.length; i++) {
-          if (trimmed[i] == '{') {
-            depth++;
-          } else if (trimmed[i] == '}') {
-            depth--;
-            if (depth == 0) {
-              closeBraceIndex = i;
-              break;
-            }
-          }
-        }
-        if (closeBraceIndex == -1) return null;
-        final inner = trimmed
-            .substring(closeParenIndex + 2, closeBraceIndex)
-            .trimRight();
-        return Constructor((c) {
-          c.factory = true;
-          c.name = name;
-          c.body = Code(inner);
-        });
-      }
+      bodyCode = factory.bodyCode;
     }
 
-    return null;
+    // Process bodyCode (mirrors helpers.generateFactoryMethod logic)
+    if (bodyCode.contains('return ') && bodyCode.endsWith(';')) {
+      bodyCode = bodyCode.substring(7, bodyCode.length - 1);
+    }
+
+    if (!useAbstractFactoryCall) {
+      // Strip $ prefix from class references in real factory bodies
+      final dollarPattern = String.fromCharCode(0x24);
+      final plainClassName = factory.className.replaceAll(dollarPattern, '');
+      bodyCode = bodyCode
+          .replaceAll('${plainClassName}._', '${classNameTrimmed}._')
+          .replaceAll(dollarPattern, '');
+    }
+
+    // Build parameters from structured data
+    final params = <Parameter>[];
+
+    for (final p in factory.parameters) {
+      final cleanType = helpers.replaceDollarTypesWithConcrete(p.type);
+      params.add(Parameter((param) {
+        param.name = p.name;
+        param.type = referType(cleanType);
+        if (p.isNamed) {
+          param.named = true;
+          param.required = p.isRequired;
+        }
+        if (p.hasDefaultValue && p.defaultValue != null) {
+          param.defaultTo = Code(p.defaultValue!);
+        }
+      }));
+    }
+
+    return Constructor((c) {
+      c.factory = true;
+      c.name = factory.name;
+      c.lambda = true;
+      c.body = Code(bodyCode);
+      c.optionalParameters.addAll(params);
+    });
   }
 }

--- a/zorphy/lib/src/generators/factory_method_generator.dart
+++ b/zorphy/lib/src/generators/factory_method_generator.dart
@@ -60,7 +60,7 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
     if (useAbstractFactoryCall) {
       // Static method delegated to abstract class
       final callArgs = factory.parameters
-          .map((p) => '${p.name}: ${p.name}')
+          .map((p) => p.isNamed ? '${p.name}: ${p.name}' : p.name)
           .join(', ');
       bodyCode = '${factory.className}.${factory.name}($callArgs)';
     } else {
@@ -68,25 +68,26 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
     }
 
     // Process bodyCode (mirrors helpers.generateFactoryMethod logic)
-    if (bodyCode.contains('return ') && bodyCode.endsWith(';')) {
-      bodyCode = bodyCode.substring(7, bodyCode.length - 1);
+    final trimmedBody = bodyCode.trim();
+    if (trimmedBody.startsWith('return ') && trimmedBody.endsWith(';')) {
+      bodyCode = trimmedBody.substring(7, trimmedBody.length - 1);
     }
 
     if (!useAbstractFactoryCall) {
       // Strip $ prefix from class references in real factory bodies
-      final dollarPattern = String.fromCharCode(0x24);
-      final plainClassName = factory.className.replaceAll(dollarPattern, '');
+      final plainClassName = factory.className.replaceAll('\$', '');
       bodyCode = bodyCode
-          .replaceAll('${plainClassName}._', '${classNameTrimmed}._')
-          .replaceAll(dollarPattern, '');
+          .replaceAll('${factory.className}._', '${classNameTrimmed}._')
+          .replaceAll('${plainClassName}._', '${classNameTrimmed}._');
     }
 
     // Build parameters from structured data
-    final params = <Parameter>[];
+    final requiredParams = <Parameter>[];
+    final namedParams = <Parameter>[];
 
     for (final p in factory.parameters) {
       final cleanType = helpers.replaceDollarTypesWithConcrete(p.type);
-      params.add(Parameter((param) {
+      final param = Parameter((param) {
         param.name = p.name;
         param.type = referType(cleanType);
         if (p.isNamed) {
@@ -96,7 +97,13 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
         if (p.hasDefaultValue && p.defaultValue != null) {
           param.defaultTo = Code(p.defaultValue!);
         }
-      }));
+      });
+
+      if (p.isNamed) {
+        namedParams.add(param);
+      } else {
+        requiredParams.add(param);
+      }
     }
 
     return Constructor((c) {
@@ -104,7 +111,8 @@ class FactoryMethodGenerator extends ConcreteClassGenerator {
       c.name = factory.name;
       c.lambda = true;
       c.body = Code(bodyCode);
-      c.optionalParameters.addAll(params);
+      c.requiredParameters.addAll(requiredParams);
+      c.optionalParameters.addAll(namedParams);
     });
   }
 }


### PR DESCRIPTION
Closes #62

## Problem
Generated delegating factory constructors dropped their parameter lists, producing code like `factory Chat.create() => $Chat.create(message: message)` — the `message` param was missing, causing INSTANCE_MEMBER_ACCESS_FROM_FACTORY and UNDEFINED_IDENTIFIER errors.

The root cause was a string round-trip: `helpers.generateFactoryMethod` correctly produced params, but `_parseFactoryString` in `factory_method_generator.dart` only extracted the name and body — never the parameter list.

## Fix
Replaced the string round-trip with direct `Constructor` construction from structured `FactoryMethodInfo`. The `FactoryParameterInfo` list (which already has `isNamed`, `isRequired`, `type`, `defaultValue`) is now mapped directly into code_builder `Parameter` objects.

## Verification
- `dart analyze`: 0 INSTANCE_MEMBER_ACCESS_FROM_FACTORY / UNDEFINED_IDENTIFIER errors
- `dart test`: all 72 tests pass, 0 failures
- Spot-checked: `factory Chat.create({required UserMessage message})`, `factory AssistantMessage.create({required String text, ...})`, `factory TestWithFactory.create({required String id})` — all with full param lists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal structure of factory method generation for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->