### PR TITLE
fix: correct raw-string dollar escaping so nested patch methods generate (Closes #63)

### DIFF
--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -23,7 +23,7 @@ class PatchGenerator extends ConcreteClassGenerator {
   List<Spec> generateSpec(GenerationContext context) {
     final metadata = context.metadata;
     final config = context.config;
-    final classNameTrimmed = metadata.cleanName.replaceAll(r'\$', '');
+    final classNameTrimmed = metadata.cleanName.replaceAll(r'$', '');
     final specs = <Spec>[];
 
     // Main patchWith method
@@ -161,7 +161,7 @@ class PatchClassGenerator extends ConcreteClassGenerator {
   List<Spec> generateSpec(GenerationContext context) {
     final metadata = context.metadata;
     final knownClasses = metadata.allAnnotatedClasses.keys
-        .map((k) => k.replaceAll(r'\$', ''))
+        .map((k) => k.replaceAll(r'$', ''))
         .toList();
     final genericTypeNames = metadata.generics.map((g) => g.name).toList();
     final code = helpers.getPatchClass(


### PR DESCRIPTION
Closes #63

## Problem
Generated Patch classes no longer emitted nested-patch builder methods (e.g. `withAddressPatch`, `withAddressPatchFunc`) for fields whose type is another zorphy entity. The documented nested-patching API and example code rely on these methods.

## Root cause
Commit fa3d4ce (retire legacy StringBuffer emission) introduced a typo when converting `PatchClassGenerator` from the old pipeline to the new one. The `replaceAll` call to strip `$` from class names used `r


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dollar-sign removal during patch generation, improving the accuracy of generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->