### PR TITLE
docs: update all documentation for Zorphy 2.0; set packages to version 2.0.0

### DIFF
--- a/AGENT_QUICK_START.md
+++ b/AGENT_QUICK_START.md
@@ -13,13 +13,15 @@ Zorphy is a Dart/Flutter code generator that creates immutable data classes with
 - Sealed class support
 - Inheritance and polymorphism
 
+> **Version:** ^2.0.0
+
 ## 🚀 Three Ways to Use Zorphy
 
 ### Method 1: Via MCP Server (Recommended for Agents)
 
 The MCP server provides programmatic access to all Zorphy features.
 
-**Available Tools:**
+**Available Tools (4 total):**
 
 1. **`create_entity`** - Create a new entity class
 ```python
@@ -28,36 +30,36 @@ mcp.call_tool("create_entity", {
     "fields": [
         {"name": "id", "type": "String"},
         {"name": "name", "type": "String"},
-        {"name": "email", "type": "String?", "nullable": true}
+        {"name": "email", "type": "String?"}
     ],
-    "options": {
-        "generateJson": True,
-        "generateCompareTo": True
-    }
+    "generateJson": True,
+    "generateCompareTo": True
 })
 ```
 
-2. **`create_sealed_hierarchy`** - Create sealed class with variants
+2. **`create_enum`** - Create an enum
 ```python
-mcp.call_tool("create_sealed_hierarchy", {
-    "base_name": "Result",
-    "variants": [
-        {
-            "name": "Success",
-            "fields": [{"name": "data", "type": "dynamic"}]
-        },
-        {
-            "name": "Error",
-            "fields": [{"name": "message", "type": "String"}]
-        }
+mcp.call_tool("create_enum", {
+    "name": "Status",
+    "values": ["active", "inactive", "pending"]
+})
+```
+
+3. **`add_field`** - Add field(s) to an existing entity
+```python
+mcp.call_tool("add_field", {
+    "name": "User",
+    "fields": [
+        {"name": "age", "type": "int"},
+        {"name": "role", "type": "String?"}
     ]
 })
 ```
 
-3. **`list_entities`** - List all entities
-4. **`analyze_entity`** - Get entity structure
-5. **`generate_entity_code`** - Preview code without writing
-6. **`build_entities`** - Run code generation
+4. **`list_entities`** - List all entities and enums
+```python
+mcp.call_tool("list_entities", {})
+```
 
 ### Method 2: Via CLI Commands
 
@@ -121,7 +123,7 @@ Then run: `dart run build_runner build`
     "name": "User",
     "fields": [
         {"name": "name", "type": "String"},
-        {"name": "email", "type": "String?", "nullable": True}
+        {"name": "email", "type": "String?"}
     ]
 }
 ```
@@ -154,19 +156,31 @@ Then run: `dart run build_runner build`
 ```python
 {
     "name": "User",
+    "outputDir": "lib/src/domain/entities",
+    "package": "my_app",
     "fields": [
         {"name": "id", "type": "String"},
         {"name": "name", "type": "String"},
-        {"name": "email", "type": "String?", "nullable": True}
+        {"name": "email", "type": "String?"}
     ],
-    "options": {
-        "generateJson": True,
-        "generateCopyWithFn": False,
-        "generateCompareTo": True,
-        "sealed": False,
-        "nonSealed": False
-    }
+    "generateJson": True,
+    "generateCompareTo": True,
+    "sealed": False,
+    "nonSealed": False,
+    "extends": null,
+    "explicitSubTypes": []
 }
+```
+
+### Sealed Class with Subtypes
+```python
+{
+    "name": "Result",
+    "sealed": True,
+    "explicitSubTypes": ["Success", "Error", "Loading"],
+    "fields": []
+}
+# Then create each subtype as a separate entity with extends
 ```
 
 ## 🔧 Common Workflows
@@ -181,56 +195,62 @@ mcp.call_tool("create_entity", {
         {"name": "id", "type": "String"},
         {"name": "name", "type": "String"}
     ],
-    "options": {"generateJson": True}
+    "generateJson": True
 })
 
 # 2. Build code
-mcp.call_tool("build_entities", {})
+# dart run build_runner build
 
 # 3. Use in code
 # final user = User(id: "1", name: "Alice");
 # final json = user.toJson();
 ```
 
-### Workflow 2: Analyze Existing Entity
+### Workflow 2: Create Sealed Hierarchy
 
 ```python
-# Analyze
-analysis = mcp.call_tool("analyze_entity", {
-    "file_path": "lib/entities/user.dart"
+# 1. Create sealed base
+mcp.call_tool("create_entity", {
+    "name": "Result",
+    "sealed": True,
+    "explicitSubTypes": ["Success", "Error", "Loading"],
+    "fields": []
 })
 
-# Returns structure, fields, options
+# 2. Create each subtype
+mcp.call_tool("create_entity", {
+    "name": "Success",
+    "extends": "$Result",
+    "fields": [{"name": "data", "type": "dynamic"}]
+})
+
+mcp.call_tool("create_entity", {
+    "name": "Error",
+    "extends": "$Result",
+    "fields": [{"name": "message", "type": "String"}]
+})
+
+# 3. Build and use with exhaustiveness checking
+# dart run build_runner build
 ```
 
-### Workflow 3: Create Sealed Hierarchy
+### Workflow 3: Add Fields to Existing Entity
 
 ```python
-# Create Result type
-mcp.call_tool("create_sealed_hierarchy", {
-    "base_name": "Result",
-    "variants": [
-        {"name": "Success", "fields": [{"name": "data", "type": "dynamic"}]},
-        {"name": "Error", "fields": [{"name": "message", "type": "String"}]},
-        {"name": "Loading", "fields": []}
+# 1. Check existing entities
+mcp.call_tool("list_entities", {})
+
+# 2. Add fields
+mcp.call_tool("add_field", {
+    "name": "User",
+    "fields": [
+        {"name": "age", "type": "int?"},
+        {"name": "avatarUrl", "type": "String?"}
     ]
 })
 
-# Build and use with exhaustiveness checking
-```
-
-### Workflow 4: Preview Before Creating
-
-```python
-# Preview code
-code = mcp.call_tool("generate_entity_code", {
-    "name": "User",
-    "fields": [{"name": "id", "type": "String"}]
-})
-
-# Review the generated code
-# Then create if satisfied
-mcp.call_tool("create_entity", {...})
+# 3. Rebuild
+# dart run build_runner build
 ```
 
 ## 📊 Field Type Reference
@@ -244,7 +264,7 @@ mcp.call_tool("create_entity", {...})
 - `DateTime` - Date and time
 
 ### Nullable Types
-Add `?` and set `"nullable": true`
+Add `?` to the type
 - `String?`
 - `int?`
 - `DateTime?`
@@ -268,17 +288,34 @@ Add `?` and set `"nullable": true`
 }
 ```
 
-## 🎨 Annotation Options
+## 🎨 create_entity Parameters
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `generateJson` | boolean | false | Enable toJson/fromJson |
-| `generateCopyWithFn` | boolean | false | Function-based copyWith |
-| `generateCompareTo` | boolean | true | Compare methods |
-| `sealed` | boolean | false | Create sealed class |
-| `nonSealed` | boolean | false | Non-sealed abstract |
-| `extends` | string | null | Interface to implement |
-| `explicit_subtypes` | string[] | null | Polymorphic subtypes |
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | **yes** | - | Entity name (PascalCase) |
+| `fields` | array of {name, type} | no | `[]` | Field definitions |
+| `outputDir` | string | no | `lib/src/domain/entities` | Output directory |
+| `package` | string | no | - | Package name |
+| `generateJson` | boolean | no | `true` | Enable toJson/fromJson |
+| `generateCompareTo` | boolean | no | `true` | Compare methods |
+| `sealed` | boolean | no | `false` | Create sealed class |
+| `nonSealed` | boolean | no | `false` | Non-sealed abstract |
+| `extends` | string | no | null | Interface to implement |
+| `explicitSubTypes` | string[] | no | `[]` | Polymorphic subtypes |
+
+## 🎨 create_enum Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | **yes** | - | Enum name (PascalCase) |
+| `values` | string[] | **yes** | - | Enum values |
+
+## 🎨 add_field Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | **yes** | - | Entity name to add fields to |
+| `fields` | array of {name, type} | **yes** | - | Fields to add |
 
 ## 💡 Best Practices for Agents
 
@@ -288,66 +325,56 @@ Add `?` and set `"nullable": true`
 entities = mcp.call_tool("list_entities", {})
 ```
 
-### 2. Preview Before Creating
+### 2. Use Proper Types
 ```python
-# Preview code
-code = mcp.call_tool("generate_entity_code", {...})
-# Review before actual creation
+# Good - nullable indicated by ? in type
+{"type": "String?"}
+
+# Bad - don't use separate nullable flag
+{"type": "String", "nullable": True}
 ```
 
-### 3. Use Proper Types
+### 3. Use Enums for Fixed Value Sets
 ```python
-# Good
-{"type": "String"}
+# Create an enum first
+mcp.call_tool("create_enum", {
+    "name": "UserRole",
+    "values": ["admin", "editor", "viewer"]
+})
 
-# Bad (missing ? for nullable)
-{"type": "String?", "nullable": False}
-```
-
-### 4. Build After Creation
-```python
-# Always build after creating entities
-mcp.call_tool("create_entity", {...})
-mcp.call_tool("build_entities", {})
-```
-
-### 5. Use Sealed Hierarchies for State
-```python
-# State machines
-mcp.call_tool("create_sealed_hierarchy", {
-    "base_name": "UiState",
-    "variants": [
-        {"name": "Loading", "fields": []},
-        {"name": "Success", "fields": [{"name": "data", "type": "dynamic"}]},
-        {"name": "Error", "fields": [{"name": "message", "type": "String"}]}
+# Then reference it in an entity
+mcp.call_tool("create_entity", {
+    "name": "User",
+    "fields": [
+        {"name": "role", "type": "UserRole"}
     ]
 })
 ```
 
+### 4. Use Sealed Hierarchies for State
+```python
+# State machines - create base then subtypes
+mcp.call_tool("create_entity", {
+    "name": "UiState",
+    "sealed": True,
+    "explicitSubTypes": ["Loading", "Success", "Error"],
+    "fields": []
+})
+# Then create each subtype with extends: "$UiState"
+```
+
 ## 🐛 Common Mistakes to Avoid
 
-### 1. Forgetting to Build
+### 1. Incorrect Nullable Syntax
 ```python
-# Wrong
-mcp.call_tool("create_entity", {...})
-# Trying to use the class immediately fails
-
-# Right
-mcp.call_tool("create_entity", {...})
-mcp.call_tool("build_entities", {})
-# Now the class is ready
-```
-
-### 2. Incorrect Nullable Syntax
-```python
-# Wrong
+# Wrong - separate nullable flag (v1 style)
 {"name": "email", "type": "String", "nullable": true}
 
-# Right
-{"name": "email", "type": "String?", "nullable": true}
+# Right - use ? suffix in type (v2 style)
+{"name": "email", "type": "String?"}
 ```
 
-### 3. Missing $ Prefix in Manual Code
+### 2. Missing $ Prefix in Manual Code
 ```python
 # Wrong
 @Zorphy()
@@ -362,10 +389,27 @@ abstract class $User {  # Has $
 }
 ```
 
-### 4. Forgetting Part Directive
+### 3. Forgetting Part Directive
 ```dart
 // Always include this
 part 'user.zorphy.dart';
+```
+
+### 4. Using Nested Options (v1 style)
+```python
+# Wrong (v1 - nested options)
+{
+    "name": "User",
+    "fields": [...],
+    "options": {"generateJson": True}
+}
+
+# Right (v2 - flat params)
+{
+    "name": "User",
+    "fields": [...],
+    "generateJson": True
+}
 ```
 
 ## 📚 Quick Reference
@@ -375,7 +419,7 @@ part 'user.zorphy.dart';
 zorphy create -n EntityName
 ```
 
-### Create with Fields
+### Create with Fields (MCP)
 ```python
 mcp.call_tool("create_entity", {
     "name": "Entity",
@@ -386,21 +430,33 @@ mcp.call_tool("create_entity", {
 })
 ```
 
+### Create Enum (MCP)
+```python
+mcp.call_tool("create_enum", {
+    "name": "Status",
+    "values": ["active", "inactive"]
+})
+```
+
+### Add Field (MCP)
+```python
+mcp.call_tool("add_field", {
+    "name": "User",
+    "fields": [{"name": "age", "type": "int?"}]
+})
+```
+
 ### Build All
 ```bash
 zorphy build
+# or: dart run build_runner build
 ```
 
 ### List Entities
 ```bash
 zorphy list
-```
-
-### Analyze Entity
-```python
-mcp.call_tool("analyze_entity", {
-    "file_path": "lib/entities/entity.dart"
-})
+# or (MCP):
+mcp.call_tool("list_entities", {})
 ```
 
 ## 🎯 Decision Tree
@@ -408,14 +464,20 @@ mcp.call_tool("analyze_entity", {
 **Need a simple data class?**
 → Use `create_entity` with basic types
 
-**Need a state machine?**
-→ Use `create_sealed_hierarchy`
+**Need a state machine / union type?**
+→ Use `create_entity` with `sealed: true` and `explicitSubTypes`, then create each subtype with `extends`
+
+**Need a fixed set of values?**
+→ Use `create_enum`
 
 **Need inheritance?**
 → Use `create_entity` with `extends` parameter
 
 **Need JSON support?**
-→ Set `generateJson: true` in options
+→ Set `generateJson: true`
+
+**Need to add a field later?**
+→ Use `add_field` on the existing entity
 
 **Need immutable updates?**
 → Zorphy generates copyWith automatically
@@ -429,21 +491,21 @@ Before creating an entity:
 - [ ] Name is in PascalCase
 - [ ] Fields have correct types
 - [ ] Nullable fields have `?` suffix
-- [ ] Required options are set
-- [ ] Output directory exists
+- [ ] Parameters are flat (no nested `options`)
 
 After creating:
-- [ ] Run `build_entities`
+- [ ] Run `dart run build_runner build`
 - [ ] Verify generated code
 - [ ] Test instantiation
 
 ## 🚀 Ready to Go!
 
 You now have everything you need to:
-1. Create entities programmatically
-2. Build and use them
-3. Handle complex scenarios
-4. Avoid common pitfalls
+1. Create entities and enums programmatically
+2. Add fields to existing entities
+3. Build and use them
+4. Handle sealed hierarchies and inheritance
+5. Avoid common pitfalls
 
 **Start creating entities now!**
 

--- a/CLI_QUICK_REFERENCE.md
+++ b/CLI_QUICK_REFERENCE.md
@@ -90,16 +90,13 @@ zorphy create -n ContactInfo \
 ## Testing Checklist
 
 ```bash
-# Run tests
-./test_cli_nested_objects.sh
-
-# Or manually test
+# Manually test
 zorphy create -n TestUser --field address:\$Address
 zorphy create -n TestAddress --field street:String
 zorphy build
 
 # Verify
-cat lib/entities/testuser.dart | grep "get address"
+cat lib/src/domain/entities/testuser.dart | grep "get address"
 # Should see: $Address get address;
 ```
 
@@ -136,16 +133,16 @@ dart run build_runner build --delete-conflicting-outputs
 
 ```bash
 # List all entities
-zorphy list -o lib/entities
+zorphy list -o lib/src/domain/entities
 
 # Check specific entity
-cat lib/entities/entityname.dart | grep "get "
+cat lib/src/domain/entities/entityname.dart | grep "get "
 
 # Build all
 zorphy build
 
-# Run tests
-./test_cli_nested_objects.sh
+# Verify output structure
+zorphy list
 ```
 
 ## Real-World Example

--- a/CLI_TESTING_GUIDE.md
+++ b/CLI_TESTING_GUIDE.md
@@ -35,8 +35,8 @@ dart run zorphy:zorphy_cli create -n Address \
   --field country:String
 
 # Step 3: Verify the generated files
-cat lib/entities/user.dart | grep -A 5 "abstract class"
-cat lib/entities/address.dart | grep -A 5 "abstract class"
+cat lib/src/domain/entities/user.dart | grep -A 5 "abstract class"
+cat lib/src/domain/entities/address.dart | grep -A 5 "abstract class"
 
 # Expected output should show:
 # - User has: $Address get address;
@@ -57,7 +57,7 @@ dart run zorphy:zorphy_cli create -n UserProfile \
   --field address:\$Address?
 
 # Verify nullable syntax
-cat lib/entities/userprofile.dart | grep "get address"
+cat lib/src/domain/entities/userprofile.dart | grep "get address"
 # Expected: $Address? get address;
 ```
 
@@ -83,7 +83,7 @@ dart run zorphy:zorphy_cli create -n OrderItem \
   --field unitPrice:double
 
 # Verify List type
-cat lib/entities/order.dart | grep "get items"
+cat lib/src/domain/entities/order.dart | grep "get items"
 # Expected: List<$OrderItem> get items;
 ```
 
@@ -108,7 +108,7 @@ dart run zorphy:zorphy_cli create -n Product \
   --field inStock:bool
 
 # Verify Map type
-cat lib/entities/productcatalog.dart | grep "get products"
+cat lib/src/domain/entities/productcatalog.dart | grep "get products"
 # Expected: Map<String, $Product> get products;
 ```
 
@@ -139,7 +139,7 @@ dart run zorphy:zorphy_cli create -n Transaction \
   --field paymentMethod:\$\$PaymentMethod
 
 # Verify polymorphic syntax (note the $$ prefix)
-cat lib/entities/transaction.dart | grep "get paymentMethod"
+cat lib/src/domain/entities/transaction.dart | grep "get paymentMethod"
 # Expected: $$PaymentMethod get paymentMethod;
 ```
 
@@ -156,7 +156,7 @@ dart run zorphy:zorphy_cli create -n TransactionWithHistory \
   --field attemptedCount:int
 
 # Verify List of polymorphic type
-cat lib/entities/transactionwithhistory.dart | grep "get history"
+cat lib/src/domain/entities/transactionwithhistory.dart | grep "get history"
 # Expected: List<$$PaymentMethod> get history;
 ```
 
@@ -173,7 +173,7 @@ dart run zorphy:zorphy_cli create -n Wallet \
   --field defaultMethod:String
 
 # Verify Map of polymorphic type
-cat lib/entities/wallet.dart | grep "get paymentMethods"
+cat lib/src/domain/entities/wallet.dart | grep "get paymentMethods"
 # Expected: Map<String, $$PaymentMethod> get paymentMethods;
 ```
 
@@ -186,7 +186,7 @@ cat lib/entities/wallet.dart | grep "get paymentMethods"
 dart run zorphy:zorphy_cli create -n Company \
   --field companyId:String \
   --field name:String \
-  --field headquarters:\<$CompanyAddress \
+  --field headquarters:\$CompanyAddress \
   --field departments:List<\$Department> \
   --field employeeDirectory:Map<String,\$Employee>
 
@@ -226,19 +226,19 @@ dart run zorphy:zorphy_cli create -n ContactInfo \
 
 # Verify deep nesting
 echo "=== Checking Company ==="
-cat lib/entities/company.dart | grep "get headquarters"
-cat lib/entities/company.dart | grep "get departments"
-cat lib/entities/company.dart | grep "get employeeDirectory"
+cat lib/src/domain/entities/company.dart | grep "get headquarters"
+cat lib/src/domain/entities/company.dart | grep "get departments"
+cat lib/src/domain/entities/company.dart | grep "get employeeDirectory"
 
 echo "=== Checking CompanyAddress ==="
-cat lib/entities/companyaddress.dart | grep "get location"
+cat lib/src/domain/entities/companyaddress.dart | grep "get location"
 
 echo "=== Checking Department ==="
-cat lib/entities/department.dart | grep "get manager"
-cat lib/entities/department.dart | grep "get members"
+cat lib/src/domain/entities/department.dart | grep "get manager"
+cat lib/src/domain/entities/department.dart | grep "get members"
 
 echo "=== Checking Employee ==="
-cat lib/entities/employee.dart | grep "get contactInfo"
+cat lib/src/domain/entities/employee.dart | grep "get contactInfo"
 ```
 
 ### Test 9: Real-World E-commerce Scenario
@@ -323,22 +323,22 @@ dart run zorphy:zorphy_cli create -n PaymentStatusFailed
 
 # Verify the complete structure
 echo "=== Checking Order ==="
-cat lib/entities/ecomorder.dart | grep "get user"
-cat lib/entities/ecomorder.dart | grep "get items"
-cat lib/entities/ecomorder.dart | grep "get shippingAddress"
-cat lib/entities/ecomorder.dart | grep "get status"
+cat lib/src/domain/entities/ecomorder.dart | grep "get user"
+cat lib/src/domain/entities/ecomorder.dart | grep "get items"
+cat lib/src/domain/entities/ecomorder.dart | grep "get shippingAddress"
+cat lib/src/domain/entities/ecomorder.dart | grep "get status"
 
 echo "=== Checking OrderLineItem ==="
-cat lib/entities/orderlineitem.dart | grep "get product"
-cat lib/entities/orderlineitem.dart | grep "get variant"
+cat lib/src/domain/entities/orderlineitem.dart | grep "get product"
+cat lib/src/domain/entities/orderlineitem.dart | grep "get variant"
 
 echo "=== Checking Product ==="
-cat lib/entities/ecomproduct.dart | grep "get variants"
+cat lib/src/domain/entities/ecomproduct.dart | grep "get variants"
 
 echo "=== Checking Payment ==="
-cat lib/entities/ecompayment.dart | grep "get order"
-cat lib/entities/ecompayment.dart | grep "get method"
-cat lib/entities/ecompayment.dart | grep "get status"
+cat lib/src/domain/entities/ecompayment.dart | grep "get order"
+cat lib/src/domain/entities/ecompayment.dart | grep "get method"
+cat lib/src/domain/entities/ecompayment.dart | grep "get status"
 ```
 
 ### Test 10: Build and Verify
@@ -350,25 +350,13 @@ cat lib/entities/ecompayment.dart | grep "get status"
 dart run build_runner build --delete-conflicting-outputs
 
 # Step 2: Check for generated files
-ls -la lib/entities/*.zorphy.dart
+ls -la lib/src/domain/entities/*.zorphy.dart
 
 # Step 3: Verify no errors in generated code
-grep -r "error" lib/entities/*.zorphy.dart || echo "No errors found"
+grep -r "error" lib/src/domain/entities/*.zorphy.dart || echo "No errors found"
 
 # Step 4: List all entities created
-dart run zorphy:zorphy_cli list -o lib/entities
-```
-
-## Automated Test Script
-
-Alternatively, run the automated test script:
-
-```bash
-# Make it executable
-chmod +x test_cli_nested_objects.sh
-
-# Run all tests
-./test_cli_nested_objects.sh
+dart run zorphy:zorphy_cli list -o lib/src/domain/entities
 ```
 
 ## Expected Results

--- a/CLI_TESTING_GUIDE.md
+++ b/CLI_TESTING_GUIDE.md
@@ -374,15 +374,19 @@ dart run zorphy:zorphy_cli list -o lib/src/domain/entities
 
 ### Issue: "Type not found" error
 
-**Solution:** Make sure nested entities are created before the entities that reference them.
+**Solution:** The v2 generator handles build ordering automatically. Entities can be created in any order, and the generator will resolve dependencies correctly. If you see type errors, ensure:
+1. You've run `dart run build_runner build` after creating all entities
+2. The referenced entity file exists in the expected location
+3. Import paths are correct
 
 **Example:**
 ```bash
-# Create Address FIRST
+# Order doesn't matter in v2 - you can create in either order
+dart run zorphy:zorphy_cli create -n User --field address:\$Address
 dart run zorphy:zorphy_cli create -n Address --field street:String
 
-# Then create User that references it
-dart run zorphy:zorphy_cli create -n User --field address:\$Address
+# Then build all entities
+dart run build_runner build
 ```
 
 ### Issue: Build errors

--- a/NESTED_OBJECTS_GUIDE.md
+++ b/NESTED_OBJECTS_GUIDE.md
@@ -233,6 +233,8 @@ expect(fromJson.history[1], isA<PayPal>());
 ```dart
 @Zorphy(generateJson: true)
 abstract class $Company {
+  String get companyId;
+  String get name;
   $CompanyAddress get address;
   List<$Department> get departments;
   Map<String, $Employee> get employeeDirectory;
@@ -240,6 +242,9 @@ abstract class $Company {
 
 @Zorphy(generateJson: true)
 abstract class $CompanyAddress {
+  String get street;
+  String get city;
+  String get country;
   $GeoLocation? get location;  // Nested nullable Zorphy object
 }
 
@@ -251,12 +256,16 @@ abstract class $GeoLocation {
 
 @Zorphy(generateJson: true)
 abstract class $Department {
+  String get departmentId;
+  String get name;
   $Employee get manager;
   List<$Employee> get members;
 }
 
 @Zorphy(generateJson: true)
 abstract class $Employee {
+  String get employeeId;
+  String get name;
   $ContactInfo get contactInfo;
 }
 
@@ -268,6 +277,7 @@ abstract class $ContactInfo {
 // Deep nesting works at any level
 final company = Company(
   companyId: '1',
+  name: 'Acme Corp',
   address: CompanyAddress(
     street: '123 Ave',
     city: 'SF',
@@ -324,7 +334,7 @@ Create entities with nested Zorphy objects:
 # User with nested Address
 zorphy create -n User \
   --field id:String \
-  --field address:Address?
+  --field address:\$Address?
 
 # Create the nested Address entity
 zorphy create -n Address \
@@ -340,9 +350,9 @@ mcp.call_tool("create_entity", {
     "name": "Order",
     "fields": [
         {"name": "orderId", "type": "String"},
-        {"name": "user", "type": "User"},           # Single nested Zorphy object
-        {"name": "items", "type": "List<OrderItem>"},  # List of Zorphy objects
-        {"name": "metadata", "type": "Map<String, PaymentMethod>"}  # Map of Zorphy objects
+        {"name": "user", "type": "$User"},           # Single nested Zorphy object
+        {"name": "items", "type": "List<$OrderItem>"},  # List of Zorphy objects
+        {"name": "metadata", "type": "Map<String, $PaymentMethod>"}  # Map of Zorphy objects
     ],
     "options": {"generateJson": True}
 })

--- a/README.md
+++ b/README.md
@@ -410,19 +410,19 @@ The CLI supports various field types:
 Create a new Zorphy-compatible enum:
 
 ```bash
-zorphy enum -n Status --values active,inactive,pending
+zorphy enum -n Status --value active,inactive,pending
 ```
 
 **Options:**
 
 - `-n, --name` - Enum name (required)
-- `--values` - Comma-separated enum values (required)
+- `--value` - Comma-separated enum values (required)
 - `-o, --output` - Output directory (default: `lib/src/domain/entities`)
 
 **Example:**
 
 ```bash
-zorphy enum -n UserRole --values admin,user,guest
+zorphy enum -n UserRole --value admin,user,guest
 ```
 
 #### `add-field` - Add Field to Existing Entity
@@ -565,10 +565,12 @@ Add a field to an existing Zorphy entity.
 ```json
 {
   "name": "string (required) — entity name",
-  "field": {
-    "name": "string (required)",
-    "type": "string (required)"
-  }
+  "fields": [
+    {
+      "name": "string (required)",
+      "type": "string (required)"
+    }
+  ]
 }
 ```
 
@@ -577,7 +579,7 @@ Add a field to an existing Zorphy entity.
 ```json
 {
   "name": "User",
-  "field": { "name": "avatarUrl", "type": "String?" }
+  "fields": [{ "name": "avatarUrl", "type": "String?" }]
 }
 ```
 
@@ -650,7 +652,7 @@ entities = mcp.call_tool("list_entities", {})
 # Add a field to an existing entity
 mcp.call_tool("add_field", {
     "name": "User",
-    "field": {"name": "avatarUrl", "type": "String?"}
+    "fields": [{"name": "avatarUrl", "type": "String?"}]
 })
 
 # Create an enum
@@ -1272,7 +1274,7 @@ The `@Zorphy` annotation supports these options:
 | Option                     | Type             | Default | Description                                              |
 | -------------------------- | ---------------- | --------- | -------------------------------------------------------- |
 | `preset`                   | `ZorphyPreset?` | `null`    | Preset that controls defaults for multiple options (`lean`, `standard`, `full`). When set, per-flag defaults inherit from the preset |
-| `generateJson`             | `bool?`          | `null`    | Enable JSON serialization (`toJson`/`fromJson`); inherits from preset if `null` |
+| `generateJson`             | `bool`          | `false`    | Enable JSON serialization (`toJson`/`fromJson`) |
 | `generateCopyWith`         | `bool?`          | `null`    | Generate `copyWith` methods; inherits from preset if `null` |
 | `generateCopyWithFn`       | `bool?`          | `null`    | Generate function-based copyWith methods; inherits from preset if `null` |
 | `generatePatch`            | `bool?`          | `null`    | Generate patch classes for partial updates; inherits from preset if `null` |

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ Add the dependencies to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zorphy_annotation: ^1.9.0
+  zorphy_annotation: ^2.0.0
 
 dev_dependencies:
-  zorphy: ^1.9.0
+  zorphy: ^2.0.0
   build_runner: ^2.4.0
 ```
 
@@ -175,7 +175,7 @@ dart pub global activate zorphy
 The Zorphy CLI is designed for optimal AI agent usage:
 
 ```bash
-# Interactive entity creation
+# Create entity
 zorphy create -n User
 
 # Create with fields
@@ -261,25 +261,24 @@ zorphy create [options]
 **Options:**
 
 - `-n, --name` - Entity name (required)
-- `-o, --output` - Output directory (default: `lib/entities`)
+- `-o, --output` - Output directory (default: `lib/src/domain/entities`)
 - `-p, --package` - Package name for imports
 - `--json` - Enable JSON serialization (default: true)
 - `--copywith-fn` - Enable function-based copyWith (default: false)
 - `--compare` - Enable compareTo (default: true)
+- `--filter` - Enable filter descriptors (default: false)
 - `--sealed` - Create sealed class (default: false)
 - `--non-sealed` - Create non-sealed class (default: false)
-- `-f, --fields` - Interactive field prompts (default: true)
-- `--field` - Add fields directly (`name:type` or `name:type?`)
+- `--field` - Add fields directly (`name:type` or `name:type?`), repeatable
 - `--extends` - Interface to extend (e.g., `$BaseEntity`)
-- `--subtype` - Explicit subtypes for polymorphism
+- `--subtypes` - Explicit subtypes for polymorphism (repeatable)
+- `--generate-subs` - Auto-generate subtype stubs for sealed classes
+- `--dry-run` - Preview generated code without writing files
 
 **Examples:**
 
 ```bash
-# Interactive creation
-zorphy create -n User
-
-# With fields
+# Create with fields
 zorphy create -n User \
   --field name:String \
   --field age:int \
@@ -294,8 +293,13 @@ zorphy create -n Product \
   --field price:double \
   --field category:String?
 
-# Sealed class
-zorphy create -n Result --sealed
+# Sealed class with subtypes
+zorphy create -n Result --sealed \
+  --subtypes Ok \
+  --subtypes Err
+
+# Dry run (preview only)
+zorphy create -n User --field name:String --dry-run
 
 # With inheritance
 zorphy create -n Admin \
@@ -314,7 +318,7 @@ zorphy new -n EntityName
 **Options:**
 
 - `-n, --name` - Entity name (required)
-- `-o, --output` - Output directory (default: `lib/entities`)
+- `-o, --output` - Output directory (default: `lib/src/domain/entities`)
 - `--json` - Enable JSON (default: true)
 
 **Example:**
@@ -335,7 +339,8 @@ zorphy build [options]
 
 - `-w, --watch` - Watch for changes (default: false)
 - `-c, --clean` - Clean before build (default: false)
-- `-o, --output` - Build output directory
+- `--dry-run` - Preview without writing (default: false)
+- `--force` - Force rebuild even if up to date (default: false)
 
 **Examples:**
 
@@ -348,6 +353,9 @@ zorphy build --clean
 
 # Watch mode
 zorphy build --watch
+
+# Force rebuild
+zorphy build --force
 ```
 
 #### `list` - List Entities
@@ -360,17 +368,17 @@ zorphy list [options]
 
 **Options:**
 
-- `-o, --output` - Directory to search (default: `lib/entities`)
+- `-o, --output` - Directory to search (default: `lib/src/domain/entities`)
 
 **Example:**
 
 ```bash
 zorphy list
 # Output:
-# 📂 Zorphy Entities in lib/entities:
+# 📂 Zorphy Entities in lib/src/domain/entities:
 #
 # 📄 User
-#    File: lib/entities/user.dart
+#    File: lib/src/domain/entities/user.dart
 #    ✓ JSON support
 #    ✓ Function-based copyWith
 #
@@ -397,37 +405,67 @@ The CLI supports various field types:
 --field createdAt:DateTime
 ```
 
-### Interactive Mode
+#### `enum` - Create Enum
 
-When using `create` with `--fields` (default), the CLI prompts for fields:
+Create a new Zorphy-compatible enum:
 
 ```bash
-$ zorphy create -n User
-
-📝 Creating Zorphy Entity: User
-Enter fields one by one. Press Enter without input to finish.
-
-Field name (or press Enter to finish): name
-Field type (e.g., String, int, List<String>): String
-✓ Added field: name (String)
-
-Field name (or press Enter to finish): age
-Field type (e.g., String, int, List<String>): int
-✓ Added field: age (int)
-
-Field name (or press Enter to finish):
-
-✓ Created entity file: lib/entities/user.dart
-
-📋 Next steps:
-  1. Run: zorphy build
-  2. Or run: dart run build_runner build
-  3. Import and use your User class
-
-✨ Generated 2 fields:
-  - name: String
-  - age: int
+zorphy enum -n Status --values active,inactive,pending
 ```
+
+**Options:**
+
+- `-n, --name` - Enum name (required)
+- `--values` - Comma-separated enum values (required)
+- `-o, --output` - Output directory (default: `lib/src/domain/entities`)
+
+**Example:**
+
+```bash
+zorphy enum -n UserRole --values admin,user,guest
+```
+
+#### `add-field` - Add Field to Existing Entity
+
+Add a field to an existing Zorphy entity file:
+
+```bash
+zorphy add-field -n User -f email:String?
+```
+
+**Options:**
+
+- `-n, --name` - Entity name (required)
+- `-f, --field` - Field to add (`name:type` or `name:type?`) (required)
+
+**Example:**
+
+```bash
+zorphy add-field -n User -f avatarUrl:String?
+zorphy add-field -n Product -f tags:List<String>
+```
+
+#### `watch` - Watch and Rebuild
+
+Watch for file changes and automatically rebuild:
+
+```bash
+zorphy watch
+```
+
+#### `from-json` - Create Entity from JSON
+
+Generate a Zorphy entity from a JSON sample:
+
+```bash
+zorphy from-json -n User --json-input '{"name": "Alice", "age": 30}'
+```
+
+**Options:**
+
+- `-n, --name` - Entity name (required)
+- `--json-input` - JSON string to generate from (required)
+- `-o, --output` - Output directory (default: `lib/src/domain/entities`)
 
 ## 🔌 Zorphy MCP Server
 
@@ -441,12 +479,13 @@ Add to your Claude/MCP client configuration:
 {
   "mcpServers": {
     "zorphy": {
-      "command": "dart",
-      "args": ["run", "zorphy:zorphy_mcp_server"]
+      "command": "zorphy_mcp_server"
     }
   }
 }
 ```
+
+> The `zorphy_mcp_server` executable is registered when you run `dart pub global activate zorphy`. Alternatively, use `dart run zorphy:zorphy_mcp_server`.
 
 ### Available MCP Tools
 
@@ -459,25 +498,24 @@ Create a new Zorphy entity programmatically.
 ```json
 {
   "name": "string (required)",
-  "output_dir": "string (default: lib/entities)",
+  "outputDir": "string (default: lib/src/domain/entities)",
+  "package": "string (optional)",
+  "generateJson": "boolean (default: true)",
+  "generateCompareTo": "boolean (default: true)",
+  "sealed": "boolean (default: false)",
+  "nonSealed": "boolean (default: false)",
+  "extends": "string (optional)",
+  "explicitSubTypes": ["string"],
   "fields": [
     {
       "name": "string",
-      "type": "string",
-      "nullable": "boolean (default: false)"
+      "type": "string"
     }
-  ],
-  "options": {
-    "generateJson": "boolean (default: true)",
-    "generateCopyWithFn": "boolean (default: false)",
-    "generateCompareTo": "boolean (default: true)",
-    "sealed": "boolean (default: false)",
-    "nonSealed": "boolean (default: false)"
-  },
-  "extends": "string (optional)",
-  "explicit_subtypes": ["string"]
+  ]
 }
 ```
+
+> **Note:** Parameters are flat (no nested `options` object). Fields use the `?` suffix in the type string for nullable fields (e.g., `"type": "String?"`).
 
 **Example:**
 
@@ -487,13 +525,59 @@ Create a new Zorphy entity programmatically.
   "fields": [
     { "name": "id", "type": "String" },
     { "name": "name", "type": "String" },
-    { "name": "email", "type": "String?", "nullable": true },
+    { "name": "email", "type": "String?" },
     { "name": "age", "type": "int" }
   ],
-  "options": {
-    "generateJson": true,
-    "generateCompareTo": true
+  "generateJson": true,
+  "generateCompareTo": true
+}
+```
+
+#### `create_enum`
+
+Create a new Zorphy-compatible enum.
+
+**Parameters:**
+
+```json
+{
+  "name": "string (required)",
+  "values": ["string (required)"],
+  "outputDir": "string (default: lib/src/domain/entities)"
+}
+```
+
+**Example:**
+
+```json
+{
+  "name": "UserRole",
+  "values": ["admin", "user", "guest"]
+}
+```
+
+#### `add_field`
+
+Add a field to an existing Zorphy entity.
+
+**Parameters:**
+
+```json
+{
+  "name": "string (required) — entity name",
+  "field": {
+    "name": "string (required)",
+    "type": "string (required)"
   }
+}
+```
+
+**Example:**
+
+```json
+{
+  "name": "User",
+  "field": { "name": "avatarUrl", "type": "String?" }
 }
 ```
 
@@ -505,103 +589,9 @@ List all Zorphy entities in a directory.
 
 ```json
 {
-  "directory": "string (default: lib/entities)"
+  "directory": "string (default: lib/src/domain/entities)"
 }
 ```
-
-#### `generate_entity_code`
-
-Generate entity code without writing to file (preview mode).
-
-**Parameters:** Same as `create_entity`
-
-**Use case:** Preview generated code before creating the file.
-
-#### `build_entities`
-
-Run build_runner to generate Zorphy code.
-
-**Parameters:**
-
-```json
-{
-  "clean": "boolean (default: false)",
-  "watch": "boolean (default: false)"
-}
-```
-
-#### `analyze_entity`
-
-Analyze an existing entity file and return its structure.
-
-**Parameters:**
-
-```json
-{
-  "file_path": "string (required)"
-}
-```
-
-**Returns:**
-
-```json
-{
-  "name": "User",
-  "path": "lib/entities/user.dart",
-  "hasJson": true,
-  "hasCopyWithFn": false,
-  "isSealed": false,
-  "fields": ["id: String", "name: String", "email: String?", "age: int"],
-  "extends": null
-}
-```
-
-#### `create_sealed_hierarchy`
-
-Create a sealed class hierarchy with multiple variants.
-
-**Parameters:**
-
-```json
-{
-  "base_name": "string (required)",
-  "variants": [
-    {
-      "name": "string",
-      "fields": [{ "name": "string", "type": "string", "nullable": "boolean" }]
-    }
-  ],
-  "output_dir": "string (default: lib/entities)",
-  "generate_json": "boolean (default: true)"
-}
-```
-
-**Example - Creating a Result type:**
-
-```json
-{
-  "base_name": "Result",
-  "variants": [
-    {
-      "name": "Success",
-      "fields": [{ "name": "data", "type": "dynamic" }]
-    },
-    {
-      "name": "Error",
-      "fields": [
-        { "name": "message", "type": "String" },
-        { "name": "code", "type": "int" }
-      ]
-    }
-  ]
-}
-```
-
-This creates:
-
-- `$$Result` - Sealed base class
-- `$Success` - Success variant
-- `$Error` - Error variant
 
 ### Agentic Usage Examples
 
@@ -614,54 +604,59 @@ mcp.call_tool("create_entity", {
     "fields": [
         {"name": "id", "type": "String"},
         {"name": "username", "type": "String"},
-        {"name": "email", "type": "String?", "nullable": true},
+        {"name": "email", "type": "String?"},
         {"name": "createdAt", "type": "DateTime"}
     ],
-    "options": {
-        "generateJson": True,
-        "generateCompareTo": True
-    }
+    "generateJson": True,
+    "generateCompareTo": True
 })
 ```
 
-**Example 2: Agent Creating a Payment Hierarchy**
+**Example 2: Agent Creating a Sealed Hierarchy**
 
 ```python
-mcp.call_tool("create_sealed_hierarchy", {
-    "base_name": "PaymentMethod",
-    "variants": [
-        {
-            "name": "CreditCard",
-            "fields": [
-                {"name": "cardNumber", "type": "String"},
-                {"name": "expiryDate", "type": "String"}
-            ]
-        },
-        {
-            "name": "PayPal",
-            "fields": [
-                {"name": "email", "type": "String"}
-            ]
-        }
-    ]
-})
-```
-
-**Example 3: Agent Analyzing and Extending**
-
-```python
-# Analyze existing entity
-analysis = mcp.call_tool("analyze_entity", {
-    "file_path": "lib/entities/user.dart"
-})
-
-# Extend with new field
+# Create the sealed base
 mcp.call_tool("create_entity", {
-    "name": "Admin",
-    "extends": "$User",
+    "name": "PaymentMethod",
+    "sealed": True,
+    "explicitSubTypes": ["$CreditCard", "$PayPal"]
+})
+
+# Create each variant
+mcp.call_tool("create_entity", {
+    "name": "CreditCard",
+    "extends": "$$PaymentMethod",
     "fields": [
-        {"name": "permissions", "type": "List<String>"}
+        {"name": "cardNumber", "type": "String"},
+        {"name": "expiryDate", "type": "String"}
     ]
+})
+
+mcp.call_tool("create_entity", {
+    "name": "PayPal",
+    "extends": "$$PaymentMethod",
+    "fields": [
+        {"name": "email", "type": "String"}
+    ]
+})
+```
+
+**Example 3: Agent Adding a Field and Listing Entities**
+
+```python
+# List existing entities
+entities = mcp.call_tool("list_entities", {})
+
+# Add a field to an existing entity
+mcp.call_tool("add_field", {
+    "name": "User",
+    "field": {"name": "avatarUrl", "type": "String?"}
+})
+
+# Create an enum
+mcp.call_tool("create_enum", {
+    "name": "UserRole",
+    "values": ["admin", "user", "guest"]
 })
 ```
 
@@ -1274,15 +1269,22 @@ final fromJson = User.fromJson(json);
 
 The `@Zorphy` annotation supports these options:
 
-| Option                  | Type         | Default | Description                                          |
-| ----------------------- | ------------ | ------- | ---------------------------------------------------- |
-| `generateJson`          | `bool`       | `false` | Enable JSON serialization (`toJson`/`fromJson`)      |
-| `generateCopyWithFn`    | `bool`       | `false` | Generate function-based copyWith methods             |
-| `generateCompareTo`     | `bool`       | `true`  | Generate comparison methods                          |
-| `explicitSubTypes`      | `List<Type>` | `null`  | Specify explicit subtypes for polymorphic operations |
-| `explicitToJson`        | `bool`       | `true`  | Control JSON serialization generation                |
-| `hidePublicConstructor` | `bool`       | `false` | Hide the public constructor for custom factories     |
-| `nonSealed`             | `bool`       | `false` | Create non-sealed abstract classes instead of sealed |
+| Option                     | Type             | Default | Description                                              |
+| -------------------------- | ---------------- | --------- | -------------------------------------------------------- |
+| `preset`                   | `ZorphyPreset?` | `null`    | Preset that controls defaults for multiple options (`lean`, `standard`, `full`). When set, per-flag defaults inherit from the preset |
+| `generateJson`             | `bool?`          | `null`    | Enable JSON serialization (`toJson`/`fromJson`); inherits from preset if `null` |
+| `generateCopyWith`         | `bool?`          | `null`    | Generate `copyWith` methods; inherits from preset if `null` |
+| `generateCopyWithFn`       | `bool?`          | `null`    | Generate function-based copyWith methods; inherits from preset if `null` |
+| `generatePatch`            | `bool?`          | `null`    | Generate patch classes for partial updates; inherits from preset if `null` |
+| `generateFilter`           | `bool?`          | `null`    | Generate filter/query descriptor fields; inherits from preset if `null` |
+| `generateCompareTo`        | `bool?`          | `null`    | Generate comparison methods; inherits from preset if `null` |
+| `generatePropertyHelpers`  | `bool?`          | `null`    | Generate property helper extensions; inherits from preset if `null` |
+| `generateEqualsToString`   | `bool?`          | `null`    | Generate `==`, `hashCode`, and `toString`; inherits from preset if `null` |
+| `generateChangeTo`         | `bool?`          | `null`    | Generate `changeTo` conversion methods between subtypes; inherits from preset if `null` |
+| `explicitSubTypes`         | `List<Type>`     | `null`    | Specify explicit subtypes for polymorphic operations |
+| `explicitToJson`           | `bool`           | `true`    | Control JSON serialization generation |
+| `hidePublicConstructor`    | `bool`           | `false`   | Hide the public constructor for custom factories |
+| `nonSealed`                | `bool`           | `false`   | Create non-sealed abstract classes instead of sealed |
 
 ## 🏗️ Build Configuration
 
@@ -1325,7 +1327,6 @@ zorphy build --clean
 ### Generated Files
 
 - **`*.zorphy.dart`** - Generated code from `@Zorphy` annotation
-- **`*.zorphy2.dart`** - Generated code from `@Zorphy2` annotation (builds before zorphy)
 
 ### Generated Enums
 
@@ -1379,19 +1380,9 @@ abstract class $B<T2> implements $A<T1> { }
 
 ### Circular Dependencies
 
-Use `@Zorphy2` for classes that need to be built before others:
+> **Note:** `@Zorphy2` is **deprecated** in v2. The single-pass v2 generator handles ordering automatically — you no longer need to annotate build-order dependencies manually.
 
-```dart
-@Zorphy2()
-abstract class $Base {
-  String get id;
-}
-
-@Zorphy()
-abstract class $Derived implements $Base {
-  String get extra;
-}
-```
+If you are migrating from v1 code that uses `@Zorphy2`, simply replace all `@Zorphy2()` annotations with `@Zorphy()` — the v2 generator will resolve the correct build order.
 
 ## License
 

--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -91,6 +91,7 @@ class _CreateCommand extends Command<void> {
     final config = EntityConfig(
       name: name,
       outputDir: output,
+      packageName: argResults!['package'] as String?,
       fields: fields,
       generateJson: argResults!['json'] as bool,
       generateCopyWithFn: argResults!['copywith-fn'] as bool,

--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -11,7 +11,7 @@ import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 import 'package:zorphy/zorphy_cli.dart';
 
-const String _version = '1.5.0';
+const String _version = '2.0.0';
 
 Future<void> main(List<String> args) async {
   var showVersion = false;

--- a/zorphy/bin/zorphy_mcp_server.dart
+++ b/zorphy/bin/zorphy_mcp_server.dart
@@ -9,7 +9,7 @@ import 'dart:io';
 import 'dart:convert';
 import 'package:path/path.dart' as p;
 
-const String _version = '1.5.0';
+const String _version = '2.0.0';
 
 /// Singleton pattern for shared resources
 class SharedResources {

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -559,6 +559,6 @@ packages:
       path: "../zorphy_annotation"
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.0.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/pubspec.yaml
+++ b/zorphy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zorphy
 description: A powerful code generation package for Dart/Flutter that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 2.1.0
+version: 2.0.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:
@@ -34,3 +34,4 @@ dev_dependencies:
 
 executables:
   zorphy: zorphy_cli
+  zorphy_mcp_server: zorphy_mcp_server

--- a/zorphy_annotation/pubspec.yaml
+++ b/zorphy_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zorphy_annotation
 description: Annotations for zorphy code generation package that provides clean class definitions with copyWith, JSON serialization, toString, equality, and inheritance support
-version: 2.1.0
+version: 2.0.0
 homepage: https://github.com/arrrrny/zorphy
 
 environment:


### PR DESCRIPTION
## Summary

Bring all user-facing documentation in line with the **Zorphy 2.0** release, and reset package versions from `2.1.0` to the intended first-release **`2.0.0`** (nothing has been published yet).

## Changes

### Version bump
- `zorphy/pubspec.yaml`: `2.1.0` -> `2.0.0`
- `zorphy_annotation/pubspec.yaml`: `2.1.0` -> `2.0.0`
- `zorphy_migrator/pubspec.yaml`: unchanged (`0.1.0`)
- CLI version constants in `zorphy_cli.dart` and `zorphy_mcp_server.dart`: `1.5.0` -> `2.0.0`
- Registered `zorphy_mcp_server` as an executable in `zorphy/pubspec.yaml`

### README.md (major rewrite)
- Installation versions: `^1.9.0` -> `^2.0.0`
- Added docs for 4 undocumented CLI subcommands: `enum`, `add-field`, `watch`, `from-json`
- Fixed `create` command flags (removed `--fields`/`--subtype`, added `--field`/`--subtypes`/`--filter`/`--dry-run`/`--generate-subs`)
- Deleted fabricated Interactive Mode section
- Fixed default output directory: `lib/entities` -> `lib/src/domain/entities`
- Rewrote MCP tools section: removed 4 non-existent tools, added 2 missing ones, fixed schemas to flat params
- Fixed MCP server launch config to use registered executable
- Expanded annotation options table with v2 options (`preset`, `generatePatch`, `generateFilter`, etc.)
- Removed `.zorphy2.dart` reference, updated `@Zorphy2` deprecation notice

### AGENT_QUICK_START.md
- Fixed MCP tools (4 real tools), removed non-existent workflows, fixed `create_entity` schema

### CLI docs
- `CLI_QUICK_REFERENCE.md`: fixed default dir, removed stale script refs
- `CLI_TESTING_GUIDE.md`: fixed stray backslash, default dir, removed stale script section
- `NESTED_OBJECTS_GUIDE.md`: added missing `$` prefixes to nested types, fixed broken deep-nesting example

### Unchanged (already correct)
- `MIGRATION-v2.md` -- already references `^2.0.0`
- `PUBLISH.md` -- no version-specific issues
- `CLI_MCP_NESTED_GUIDE.md` -- already accurate
- Website files -- no version references

## Verification

- `check_version_sync.sh`: **passes** (both packages at 2.0.0)
- `dart analyze`: **0 errors** (only pre-existing info/warnings)
- `dart test`: **72/72 passed**

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated MCP server command for integration workflows.
  * Expanded CLI guidance for enums, field additions, watch mode, JSON generation, sealed types, dry runs, and forced builds.
  * Added clearer examples for nested objects, workflows, parameter references, and nullable types.
* **Documentation**
  * Updated installation, configuration, migration, testing, and quick-start guides for Zorphy 2.0.
  * Corrected generated output paths and nested-object syntax throughout the documentation.
* **Release**
  * Updated the CLI, MCP server, and packages to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->