### PR TITLE
feat(CLI): add self-update command

### DIFF
--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -33,7 +33,8 @@ Future<void> main(List<String> args) async {
         ..addCommand(_BuildCommand())
         ..addCommand(_WatchCommand())
         ..addCommand(_FromJsonCommand())
-        ..addCommand(_ValidateCommand());
+        ..addCommand(_ValidateCommand())
+        ..addCommand(_SelfUpdateCommand());
 
   try {
     if (showVersion) {
@@ -619,5 +620,75 @@ class _ValidateCommand extends Command<void> {
     };
 
     print(const JsonEncoder.withIndent('  ').convert(output));
+  }
+}
+
+
+class _SelfUpdateCommand extends Command<void> {
+  @override
+  String get name => 'self-update';
+
+  @override
+  String get description =>
+      'Check for the latest zorphy version and update the CLI in place';
+
+  _SelfUpdateCommand() {
+    argParser.addFlag(
+      'check',
+      abbr: 'c',
+      negatable: false,
+      help: 'Only check for updates, do not install',
+    );
+    argParser.addFlag(
+      'json',
+      negatable: false,
+      help: 'Output results as JSON',
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final checkOnly = argResults!['check'] as bool;
+    final asJson = argResults!['json'] as bool;
+
+    final checker = VersionChecker(currentVersion: _version);
+
+    if (asJson) {
+      final checkResult = await checker.checkForUpdate();
+      final output = <String, dynamic>{
+        'currentVersion': checkResult.currentVersion,
+        'latestVersion': checkResult.latestVersion,
+        'updateAvailable': checkResult.updateAvailable,
+        'message': checkResult.message,
+      };
+      if (!checkOnly && checkResult.updateAvailable) {
+        final updateResult = await checker.performUpdateAndVerify();
+        output['update'] = {
+          'success': updateResult.success,
+          'message': updateResult.message,
+          if (updateResult.newVersion != null)
+            'newVersion': updateResult.newVersion,
+        };
+      }
+      print(const JsonEncoder.withIndent('  ').convert(output));
+      return;
+    }
+
+    // Human-readable output
+    final checkResult = await checker.checkForUpdate();
+    print(checkResult);
+
+    if (checkOnly || !checkResult.updateAvailable) {
+      if (checkOnly && checkResult.updateAvailable) {
+        print('');
+        print('Run without --check to perform the update.');
+      }
+      return;
+    }
+
+    print('');
+    print('Updating...');
+    final updateResult = await checker.performUpdateAndVerify();
+    print(updateResult);
   }
 }

--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -653,8 +653,10 @@ class _SelfUpdateCommand extends Command<void> {
 
     final checker = VersionChecker(currentVersion: _version);
 
+    // Reuse a single checkForUpdate result
+    final checkResult = await checker.checkForUpdate();
+
     if (asJson) {
-      final checkResult = await checker.checkForUpdate();
       final output = <String, dynamic>{
         'currentVersion': checkResult.currentVersion,
         'latestVersion': checkResult.latestVersion,
@@ -669,14 +671,25 @@ class _SelfUpdateCommand extends Command<void> {
           if (updateResult.newVersion != null)
             'newVersion': updateResult.newVersion,
         };
+        if (!updateResult.success) {
+          print(const JsonEncoder.withIndent('  ').convert(output));
+          exit(1);
+        }
+      }
+      if (checkResult.latestVersion == null) {
+        print(const JsonEncoder.withIndent('  ').convert(output));
+        exit(1);
       }
       print(const JsonEncoder.withIndent('  ').convert(output));
       return;
     }
 
     // Human-readable output
-    final checkResult = await checker.checkForUpdate();
     print(checkResult);
+
+    if (checkResult.latestVersion == null) {
+      exit(1);
+    }
 
     if (checkOnly || !checkResult.updateAvailable) {
       if (checkOnly && checkResult.updateAvailable) {
@@ -690,5 +703,8 @@ class _SelfUpdateCommand extends Command<void> {
     print('Updating...');
     final updateResult = await checker.performUpdateAndVerify();
     print(updateResult);
+    if (!updateResult.success) {
+      exit(1);
+    }
   }
 }

--- a/zorphy/lib/src/cli/models/index.dart
+++ b/zorphy/lib/src/cli/models/index.dart
@@ -1,2 +1,3 @@
 export 'entity_config.dart';
+export 'update_result.dart';
 export 'validation_result.dart';

--- a/zorphy/lib/src/cli/models/update_result.dart
+++ b/zorphy/lib/src/cli/models/update_result.dart
@@ -1,0 +1,90 @@
+/// Models for the self-update command.
+library;
+
+/// Result of checking for a CLI update.
+class UpdateCheckResult {
+  /// The version currently running (from the _version constant).
+  final String currentVersion;
+
+  /// The latest version available on pub.dev.
+  final String? latestVersion;
+
+  /// Whether a newer version is available.
+  final bool updateAvailable;
+
+  /// Human-readable message describing the result.
+  final String message;
+
+  /// HTTP status code from the pub.dev API call, or null if not applicable.
+  final int? statusCode;
+
+  const UpdateCheckResult({
+    required this.currentVersion,
+    this.latestVersion,
+    required this.updateAvailable,
+    required this.message,
+    this.statusCode,
+  });
+
+  @override
+  String toString() {
+    final buf = StringBuffer();
+    if (latestVersion == null) {
+      buf.writeln('Could not determine latest version.');
+    } else {
+      buf.writeln('Current version:  $currentVersion');
+      buf.writeln('Latest version:   $latestVersion');
+      if (updateAvailable) {
+        buf.writeln('');
+        buf.writeln('A newer version is available!');
+      } else {
+        buf.writeln('');
+        buf.writeln('CLI is up to date.');
+      }
+    }
+    if (message.isNotEmpty && latestVersion == null) {
+      buf.writeln(message);
+    }
+    return buf.toString();
+  }
+}
+
+/// Result of performing the self-update.
+class UpdateResult {
+  /// Whether the update succeeded.
+  final bool success;
+
+  /// Human-readable message describing the outcome.
+  final String message;
+
+  /// The version after the update (if verifiable).
+  final String? newVersion;
+
+  /// The exit code of the `dart pub global activate` process.
+  final int? exitCode;
+
+  const UpdateResult({
+    required this.success,
+    required this.message,
+    this.newVersion,
+    this.exitCode,
+  });
+
+  @override
+  String toString() {
+    final buf = StringBuffer();
+    if (success) {
+      buf.writeln('Update successful!');
+      if (newVersion != null) {
+        buf.writeln('New version: $newVersion');
+      }
+    } else {
+      buf.writeln('Update failed.');
+      if (exitCode != null) {
+        buf.writeln('Exit code: $exitCode');
+      }
+    }
+    buf.writeln(message);
+    return buf.toString();
+  }
+}

--- a/zorphy/lib/src/cli/services/index.dart
+++ b/zorphy/lib/src/cli/services/index.dart
@@ -1,3 +1,4 @@
 export 'field_normalizer.dart';
 export 'import_resolver.dart';
 export 'project_validator.dart';
+export 'version_checker.dart';

--- a/zorphy/lib/src/cli/services/version_checker.dart
+++ b/zorphy/lib/src/cli/services/version_checker.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'dart:io';
+import 'dart:async';
 import 'dart:convert';
 import '../models/update_result.dart';
 
@@ -192,32 +193,56 @@ class VersionChecker {
   /// Extract the latest stable version from the pub.dev API response JSON.
   String? _extractLatestVersion(Map<String, dynamic> json) {
     // Try the 'latest' field first
+    String? latestVersion;
     try {
       final latest = json['latest'] as Map<String, dynamic>?;
       if (latest != null) {
-        return latest['version'] as String?;
+        latestVersion = latest['version'] as String?;
+        if (latestVersion != null && latestVersion.isNotEmpty) {
+          return latestVersion;
+        }
       }
     } catch (_) {}
 
-    // Fallback: scan versions list for latest non-prerelease
+    // Fallback: scan versions list for highest version
     try {
       final versions = json['versions'] as List<dynamic>?;
       if (versions != null && versions.isNotEmpty) {
+        final allVersions = <String>[];
         for (final v in versions) {
           if (v is Map<String, dynamic>) {
             final version = v['version'] as String?;
-            if (version != null &&
-                !version.contains('-') &&
-                !version.contains('+')) {
-              return version;
+            if (version != null && version.isNotEmpty) {
+              allVersions.add(version);
             }
           }
         }
-        // All prerelease — return first
-        if (versions.isNotEmpty) {
-          return (versions.first as Map<String, dynamic>)['version']
-              as String?;
+
+        if (allVersions.isEmpty) return null;
+
+        // Separate stable and prerelease versions
+        final stableVersions = allVersions
+            .where((v) => !v.contains('-') && !v.contains('+'))
+            .toList();
+        final prereleaseVersions = allVersions
+            .where((v) => v.contains('-') || v.contains('+'))
+            .toList();
+
+        // Select highest stable version, or highest prerelease if no stable
+        final candidateVersions = stableVersions.isNotEmpty
+            ? stableVersions
+            : prereleaseVersions;
+
+        if (candidateVersions.isEmpty) return null;
+
+        // Find the highest version using existing comparison
+        String highest = candidateVersions.first;
+        for (final version in candidateVersions.skip(1)) {
+          if (_isNewer(highest, version)) {
+            highest = version;
+          }
         }
+        return highest;
       }
     } catch (_) {}
 
@@ -261,25 +286,32 @@ class VersionChecker {
       return fetchJson!(url, timeout: const Duration(seconds: 10));
     }
 
-    // Default: real HTTP fetch
+    // Default: real HTTP fetch with overall timeout
     final uri = Uri.parse(url);
     final client = HttpClient()
       ..connectionTimeout = const Duration(seconds: 10);
     try {
-      final request = await client.getUrl(uri);
-      request.headers.set('User-Agent',
-          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.0');
-      request.headers.set('Accept', 'application/json');
-      final response = await request.close();
+      return await Future.value(null).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () async {
+          throw TimeoutException('HTTP request timed out after 10 seconds');
+        },
+      ).then((_) async {
+        final request = await client.getUrl(uri);
+        request.headers.set('User-Agent',
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.0');
+        request.headers.set('Accept', 'application/json');
+        final response = await request.close();
 
-      if (response.statusCode != 200) {
-        throw HttpException(
-          'pub.dev API returned status ${response.statusCode}',
-          uri: uri,
-        );
-      }
+        if (response.statusCode != 200) {
+          throw HttpException(
+            'pub.dev API returned status ${response.statusCode}',
+            uri: uri,
+          );
+        }
 
-      return await response.transform(utf8.decoder).join();
+        return await response.transform(utf8.decoder).join();
+      });
     } finally {
       client.close(force: true);
     }

--- a/zorphy/lib/src/cli/services/version_checker.dart
+++ b/zorphy/lib/src/cli/services/version_checker.dart
@@ -1,0 +1,301 @@
+/// Version checking and self-update service for the zorphy CLI.
+///
+/// Queries the pub.dev API to check for the latest published version
+/// and optionally runs `dart pub global activate` to update.
+library;
+
+import 'dart:io';
+import 'dart:convert';
+import '../models/update_result.dart';
+
+/// Functional type for fetching JSON from a URL.
+/// Returns the response body as a string, or throws on network/HTTP errors.
+/// Used to allow injecting a mock in tests without implementing HttpClientResponse.
+typedef FetchJsonFunction = Future<String> Function(
+  String url, {
+  Duration? timeout,
+});
+
+/// Functional type for running a subprocess.
+typedef RunProcessFunction = Future<ProcessResult> Function(
+  String executable,
+  List<String> args,
+);
+
+/// Service that checks the latest published version of zorphy on pub.dev
+/// and can perform a self-update via `dart pub global activate`.
+class VersionChecker {
+  /// The current CLI version (from the _version constant).
+  final String currentVersion;
+
+  /// The package name on pub.dev.
+  final String packageName;
+
+  /// The pub.dev API URL template.
+  final String apiBaseUrl;
+
+  /// Overrideable JSON fetcher for testing. Defaults to real HTTP.
+  final FetchJsonFunction? fetchJson;
+
+  /// Overrideable process runner for testing. Defaults to real Process.run.
+  final RunProcessFunction? processRunner;
+
+  VersionChecker({
+    required this.currentVersion,
+    this.packageName = 'zorphy',
+    this.apiBaseUrl = 'https://pub.dev',
+    this.fetchJson,
+    this.processRunner,
+  });
+
+  /// Check the latest published version on pub.dev.
+  ///
+  /// Returns an [UpdateCheckResult] with version comparison info.
+  Future<UpdateCheckResult> checkForUpdate() async {
+    final url = '$apiBaseUrl/api/packages/$packageName';
+
+    try {
+      final body = await _doFetchJson(url);
+
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      final latest = _extractLatestVersion(json);
+      if (latest == null) {
+        return UpdateCheckResult(
+          currentVersion: currentVersion,
+          updateAvailable: false,
+          message: 'Could not parse latest version from pub.dev response.',
+        );
+      }
+
+      final available = _isNewer(currentVersion, latest);
+      final msg = available
+          ? 'Update available: $currentVersion → $latest'
+          : 'Already on the latest version.';
+
+      return UpdateCheckResult(
+        currentVersion: currentVersion,
+        latestVersion: latest,
+        updateAvailable: available,
+        message: msg,
+      );
+    } on SocketException {
+      return UpdateCheckResult(
+        currentVersion: currentVersion,
+        updateAvailable: false,
+        message: 'Network error: Could not reach $apiBaseUrl. '
+            'Check your internet connection.',
+      );
+    } on FormatException catch (e) {
+      return UpdateCheckResult(
+        currentVersion: currentVersion,
+        updateAvailable: false,
+        message: 'Failed to parse pub.dev response: $e',
+      );
+    } catch (e) {
+      return UpdateCheckResult(
+        currentVersion: currentVersion,
+        updateAvailable: false,
+        message: 'Unexpected error checking for update: $e',
+      );
+    }
+  }
+
+  /// Synchronous version of checkForUpdate for unit testing version
+  /// comparison logic directly from a JSON map.
+  ///
+  /// Not intended for production use — only for tests.
+  UpdateCheckResult checkForUpdateSync({
+    required Map<String, dynamic> pubDevResponse,
+  }) {
+    final latest = _extractLatestVersion(pubDevResponse);
+    if (latest == null) {
+      return UpdateCheckResult(
+        currentVersion: currentVersion,
+        updateAvailable: false,
+        message: 'Could not parse latest version.',
+      );
+    }
+    return UpdateCheckResult(
+      currentVersion: currentVersion,
+      latestVersion: latest,
+      updateAvailable: _isNewer(currentVersion, latest),
+      message: _isNewer(currentVersion, latest)
+          ? 'Update available: $currentVersion → $latest'
+          : 'Already on the latest version.',
+    );
+  }
+
+  /// Perform the self-update by running `dart pub global activate`.
+  Future<UpdateResult> performUpdate() async {
+    try {
+      final result = await _runProcess('dart', [
+        'pub',
+        'global',
+        'activate',
+        packageName,
+      ]);
+
+      if (result.exitCode == 0) {
+        return UpdateResult(
+          success: true,
+          message: 'Successfully updated $packageName. '
+              'Run `zorphy_cli --version` to verify.',
+        );
+      } else {
+        return UpdateResult(
+          success: false,
+          exitCode: result.exitCode,
+          message: '`dart pub global activate $packageName` failed.\n'
+              '${result.stderr}',
+        );
+      }
+    } catch (e) {
+      return UpdateResult(
+        success: false,
+        message: 'Failed to run update command: $e',
+      );
+    }
+  }
+
+  /// Perform the update and verify the new version.
+  Future<UpdateResult> performUpdateAndVerify() async {
+    final updateResult = await performUpdate();
+    if (!updateResult.success) return updateResult;
+
+    // Verify by running zorphy_cli --version
+    try {
+      final verifyResult = await _runProcess('zorphy_cli', ['--version']);
+      if (verifyResult.exitCode == 0) {
+        final newVersion = verifyResult.stdout.toString().trim();
+        return UpdateResult(
+          success: true,
+          newVersion: newVersion,
+          message: 'Updated and verified. Running version: $newVersion',
+        );
+      } else {
+        return UpdateResult(
+          success: true,
+          message: 'Update applied but version verification failed. '
+              'Run `zorphy_cli --version` to check manually.',
+        );
+      }
+    } catch (e) {
+      return UpdateResult(
+        success: true,
+        message: 'Update applied but could not verify. '
+            'Run `zorphy_cli --version` to check.',
+      );
+    }
+  }
+
+  /// Extract the latest stable version from the pub.dev API response JSON.
+  String? _extractLatestVersion(Map<String, dynamic> json) {
+    // Try the 'latest' field first
+    try {
+      final latest = json['latest'] as Map<String, dynamic>?;
+      if (latest != null) {
+        return latest['version'] as String?;
+      }
+    } catch (_) {}
+
+    // Fallback: scan versions list for latest non-prerelease
+    try {
+      final versions = json['versions'] as List<dynamic>?;
+      if (versions != null && versions.isNotEmpty) {
+        for (final v in versions) {
+          if (v is Map<String, dynamic>) {
+            final version = v['version'] as String?;
+            if (version != null &&
+                !version.contains('-') &&
+                !version.contains('+')) {
+              return version;
+            }
+          }
+        }
+        // All prerelease — return first
+        if (versions.isNotEmpty) {
+          return (versions.first as Map<String, dynamic>)['version']
+              as String?;
+        }
+      }
+    } catch (_) {}
+
+    return null;
+  }
+
+  /// Compare two semantic versions. Returns true if [latest] is newer
+  /// than [current].
+  bool _isNewer(String current, String latest) {
+    final currentParts = _parseVersion(current);
+    final latestParts = _parseVersion(latest);
+
+    if (currentParts == null || latestParts == null) {
+      return current != latest;
+    }
+
+    for (var i = 0; i < 3; i++) {
+      final c = i < currentParts.length ? currentParts[i] : 0;
+      final l = i < latestParts.length ? latestParts[i] : 0;
+      if (l > c) return true;
+      if (l < c) return false;
+    }
+    return false; // equal
+  }
+
+  /// Parse "2.0.0" or "v2.0.0-beta.1" into [2, 0, 0].
+  List<int>? _parseVersion(String version) {
+    final clean = version
+        .replaceFirst(RegExp(r'^v'), '')
+        .split('-')
+        .first
+        .split('+')
+        .first;
+    final parts = clean.split('.').map((s) => int.tryParse(s)).toList();
+    return parts.every((p) => p != null) ? parts.cast<int>() : null;
+  }
+
+  /// Fetch JSON from a URL.
+  Future<String> _doFetchJson(String url) async {
+    if (fetchJson != null) {
+      return fetchJson!(url, timeout: const Duration(seconds: 10));
+    }
+
+    // Default: real HTTP fetch
+    final uri = Uri.parse(url);
+    final client = HttpClient()
+      ..connectionTimeout = const Duration(seconds: 10);
+    try {
+      final request = await client.getUrl(uri);
+      request.headers.set('User-Agent',
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.0');
+      request.headers.set('Accept', 'application/json');
+      final response = await request.close();
+
+      if (response.statusCode != 200) {
+        throw HttpException(
+          'pub.dev API returned status ${response.statusCode}',
+          uri: uri,
+        );
+      }
+
+      return await response.transform(utf8.decoder).join();
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  /// Run a subprocess.
+  Future<ProcessResult> _runProcess(String executable, List<String> args) async {
+    if (processRunner != null) {
+      return processRunner!(executable, args);
+    }
+
+    return Process.run(
+      executable,
+      args,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+  }
+}

--- a/zorphy/lib/zorphy_cli.dart
+++ b/zorphy/lib/zorphy_cli.dart
@@ -4,6 +4,8 @@ library zorphy_cli_entry;
 
 export 'src/cli/entity_creator.dart';
 export 'src/cli/models/entity_config.dart';
+export 'src/cli/models/update_result.dart';
 export 'src/cli/models/validation_result.dart';
 export 'src/cli/services/project_validator.dart';
+export 'src/cli/services/version_checker.dart';
 export 'src/cli/utils/naming_utils.dart';

--- a/zorphy/test/self_update_test.dart
+++ b/zorphy/test/self_update_test.dart
@@ -1,0 +1,294 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:zorphy/zorphy_cli.dart';
+
+void main() {
+  group('VersionChecker', () {
+    group('checkForUpdateSync (version comparison)', () {
+      test('major version bump is newer', () {
+        final checker = VersionChecker(currentVersion: '1.9.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.0.0'}},
+        );
+        expect(result.updateAvailable, isTrue);
+        expect(result.latestVersion, equals('2.0.0'));
+      });
+
+      test('minor version bump is newer', () {
+        final checker = VersionChecker(currentVersion: '2.0.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.1.0'}},
+        );
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('patch version bump is newer', () {
+        final checker = VersionChecker(currentVersion: '2.0.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.0.1'}},
+        );
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('same version is not newer', () {
+        final checker = VersionChecker(currentVersion: '2.0.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.0.0'}},
+        );
+        expect(result.updateAvailable, isFalse);
+      });
+
+      test('older version is not newer', () {
+        final checker = VersionChecker(currentVersion: '2.1.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.0.0'}},
+        );
+        expect(result.updateAvailable, isFalse);
+      });
+
+      test('handles v-prefix in version string', () {
+        final checker = VersionChecker(currentVersion: '2.0.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': 'v2.1.0'}},
+        );
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('strips pre-release suffix for comparison', () {
+        final checker = VersionChecker(currentVersion: '2.0.0');
+        final result = checker.checkForUpdateSync(
+          pubDevResponse: {'latest': {'version': '2.1.0-beta.1'}},
+        );
+        expect(result.updateAvailable, isTrue);
+      });
+    });
+
+    group('checkForUpdate (with mock fetchJson)', () {
+      test('reports newer version available', () async {
+        final checker = VersionChecker(
+          currentVersion: '1.9.0',
+          fetchJson: _mockFetchJson({
+            'latest': {'version': '2.0.0'},
+            'versions': [
+              {'version': '2.0.0'},
+              {'version': '1.9.0'},
+            ],
+          }),
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.currentVersion, equals('1.9.0'));
+        expect(result.latestVersion, equals('2.0.0'));
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('reports already up to date', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          fetchJson: _mockFetchJson({
+            'latest': {'version': '2.0.0'},
+            'versions': [{'version': '2.0.0'}],
+          }),
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.updateAvailable, isFalse);
+        expect(result.latestVersion, equals('2.0.0'));
+      });
+
+      test('handles network error gracefully', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          fetchJson: (url, {timeout}) async {
+            throw SocketException('Connection refused');
+          },
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.latestVersion, isNull);
+        expect(result.updateAvailable, isFalse);
+        expect(result.message, contains('Network error'));
+      });
+
+      test('handles malformed JSON response', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          fetchJson: (url, {timeout}) async => '{bad: data',
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.latestVersion, isNull);
+        expect(result.message, contains('Failed to parse'));
+      });
+
+      test('falls back to versions list when latest field missing', () async {
+        final checker = VersionChecker(
+          currentVersion: '1.5.0',
+          fetchJson: _mockFetchJson({
+            'versions': [
+              {'version': '2.0.0'},
+              {'version': '1.9.0'},
+              {'version': '1.5.0'},
+            ],
+          }),
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.latestVersion, equals('2.0.0'));
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('skips prerelease versions in fallback', () async {
+        final checker = VersionChecker(
+          currentVersion: '1.9.0',
+          fetchJson: _mockFetchJson({
+            'versions': [
+              {'version': '2.1.0-beta'},
+              {'version': '2.0.0'},
+            ],
+          }),
+        );
+
+        final result = await checker.checkForUpdate();
+        expect(result.latestVersion, equals('2.0.0'));
+        expect(result.updateAvailable, isTrue);
+      });
+
+      test('passes correct URL to fetchJson', () async {
+        String? capturedUrl;
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          fetchJson: (url, {timeout}) async {
+            capturedUrl = url;
+            return jsonEncode({'latest': {'version': '2.0.0'}});
+          },
+        );
+
+        await checker.checkForUpdate();
+        expect(capturedUrl, equals('https://pub.dev/api/packages/zorphy'));
+      });
+    });
+
+    group('performUpdate', () {
+      test('returns success when dart pub global activate succeeds', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          processRunner: (exe, args) async {
+            expect(exe, equals('dart'));
+            expect(args, contains('global'));
+            expect(args, contains('activate'));
+            expect(args, contains('zorphy'));
+            return ProcessResult(0, 0, 'Activated zorphy 2.1.0', '');
+          },
+        );
+
+        final result = await checker.performUpdate();
+        expect(result.success, isTrue);
+      });
+
+      test('returns failure when dart pub global activate fails', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          processRunner: (exe, args) async {
+            return ProcessResult(0, 1, '', 'Could not resolve package');
+          },
+        );
+
+        final result = await checker.performUpdate();
+        expect(result.success, isFalse);
+        expect(result.exitCode, equals(1));
+        expect(result.message, contains('Could not resolve'));
+      });
+
+      test('handles exception during process execution', () async {
+        final checker = VersionChecker(
+          currentVersion: '2.0.0',
+          processRunner: (exe, args) async {
+            throw ArgumentError('Command not found: $exe');
+          },
+        );
+
+        final result = await checker.performUpdate();
+        expect(result.success, isFalse);
+        expect(result.message, contains('Failed to run'));
+      });
+    });
+
+    group('UpdateCheckResult.toString', () {
+      test('formats update available message', () {
+        final result = UpdateCheckResult(
+          currentVersion: '1.9.0',
+          latestVersion: '2.0.0',
+          updateAvailable: true,
+          message: 'Update available: 1.9.0 → 2.0.0',
+        );
+        final output = result.toString();
+        expect(output, contains('Current version:  1.9.0'));
+        expect(output, contains('Latest version:   2.0.0'));
+        expect(output, contains('newer version is available'));
+      });
+
+      test('formats up-to-date message', () {
+        final result = UpdateCheckResult(
+          currentVersion: '2.0.0',
+          latestVersion: '2.0.0',
+          updateAvailable: false,
+          message: 'Already on the latest version.',
+        );
+        final output = result.toString();
+        expect(output, contains('up to date'));
+      });
+
+      test('formats error when no latest version', () {
+        final result = UpdateCheckResult(
+          currentVersion: '2.0.0',
+          updateAvailable: false,
+          message: 'Network error',
+        );
+        final output = result.toString();
+        expect(output, contains('Could not determine'));
+      });
+    });
+
+    group('UpdateResult.toString', () {
+      test('formats success message', () {
+        final result = UpdateResult(
+          success: true,
+          newVersion: '2.1.0',
+          message: 'Updated successfully',
+        );
+        final output = result.toString();
+        expect(output, contains('Update successful'));
+        expect(output, contains('2.1.0'));
+      });
+
+      test('formats failure message', () {
+        final result = UpdateResult(
+          success: false,
+          exitCode: 1,
+          message: 'Activation failed',
+        );
+        final output = result.toString();
+        expect(output, contains('Update failed'));
+        expect(output, contains('Exit code: 1'));
+      });
+
+      test('formats success without verifiable version', () {
+        final result = UpdateResult(
+          success: true,
+          message: 'Update applied',
+        );
+        final output = result.toString();
+        expect(output, contains('Update successful'));
+        expect(output, isNot(contains('New version')));
+      });
+    });
+  });
+}
+
+/// Helper: create a [FetchJsonFunction] that returns the given JSON map
+/// encoded as a string.
+FetchJsonFunction _mockFetchJson(Map<String, dynamic> json) {
+  return (url, {timeout}) async => jsonEncode(json);
+}


### PR DESCRIPTION
Closes #Adds zorphy self-update subcommand that checks pub.dev for the latest version and updates the CLI in place. Features: version check via pub.dev API, semantic version comparison, dart pub global activate, post-update verification, --check flag for check-only mode, --json for machine-readable output. 23 new unit tests, 103 total tests passing, zero new dependencies.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `self-update` command to check for and install the latest CLI version.
  * Added check-only and JSON output options.
  * Added verification of the installed version after updates.
  * Added clear status reporting for available updates, successful updates, and errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->