### PR TITLE
feat(CLI): add doctor command for clean-regeneration of stale .zorphy.dart files

Closes #272

The doctor command automates the recovery workflow for stale or corrupt
generated part files (InvalidType for cross-file references). It:
1. Scans for all *.zorphy.dart files in the project
2. Deletes them (with --dry-run to preview first)
3. Runs build_runner build --delete-conflicting-outputs
4. Reports: deleted count, regenerated count, remaining InvalidType occurrences,
   and overall project health (healthy/warnings/unhealthy)

Adds:
- DoctorService with injectable dependencies for testability
- DoctorResult model with human-readable and JSON output
- _DoctorCommand following existing validate/self-update patterns
- 16 tests covering service logic, dry-run, InvalidType detection,
  multi-source-dir scanning, and result formatting

Zero new dependencies added.

### DIFF
--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -560,7 +560,7 @@ class _ValidateCommand extends Command<void> {
   Future<void> run() async {
     final dir = argResults!['dir'] as String? ?? Directory.current.path;
     final extraSources = (argResults!['source'] as List<String>?) ?? [];
-    final sourceDirs = ['lib', ...extraSources];
+    final sourceDirs = ['lib', ...extraSources.where((s) => s != 'lib')];
     final asJson = argResults!['json'] as bool;
 
     final projectDir = Directory(dir);
@@ -747,7 +747,7 @@ class _DoctorCommand extends Command<void> {
   Future<void> run() async {
     final dir = argResults!['dir'] as String? ?? Directory.current.path;
     final extraSources = (argResults!['source'] as List<String>?) ?? [];
-    final sourceDirs = ['lib', ...extraSources];
+    final sourceDirs = ['lib', ...extraSources.where((s) => s != 'lib')];
     final dryRun = argResults!['dry-run'] as bool;
     final asJson = argResults!['json'] as bool;
 

--- a/zorphy/bin/zorphy_cli.dart
+++ b/zorphy/bin/zorphy_cli.dart
@@ -34,7 +34,8 @@ Future<void> main(List<String> args) async {
         ..addCommand(_WatchCommand())
         ..addCommand(_FromJsonCommand())
         ..addCommand(_ValidateCommand())
-        ..addCommand(_SelfUpdateCommand());
+        ..addCommand(_SelfUpdateCommand())
+        ..addCommand(_DoctorCommand());
 
   try {
     if (showVersion) {
@@ -111,12 +112,13 @@ class _CreateCommand extends Command<void> {
     final result = await creator.create(config);
 
     if (result.isSuccess) {
-      print('✓ Created entity: ${result.filePath}');
-      print('\n📋 Next steps:');
+      print('Created entity: ${result.filePath}');
+      print('');
+      print('Next steps:');
       print('  1. Run: dart run build_runner build');
       print('  2. Import and use your ${config.className} class');
     } else {
-      print('❌ ${result.error}');
+      print('${result.error}');
       exit(1);
     }
   }
@@ -181,9 +183,9 @@ class _NewCommand extends Command<void> {
     final result = await creator.create(config);
 
     if (result.isSuccess) {
-      print('✓ Created entity: ${result.filePath}');
+      print('Created entity: ${result.filePath}');
     } else {
-      print('❌ ${result.error}');
+      print('${result.error}');
       exit(1);
     }
   }
@@ -218,9 +220,9 @@ class _EnumCommand extends Command<void> {
     final result = await creator.createEnum(config);
 
     if (result.isSuccess) {
-      print('✓ Created enum: ${result.filePath}');
+      print('Created enum: ${result.filePath}');
     } else {
-      print('❌ ${result.error}');
+      print('${result.error}');
       exit(1);
     }
   }
@@ -262,9 +264,9 @@ class _AddFieldCommand extends Command<void> {
     );
 
     if (result.isSuccess) {
-      print('✓ Added ${fields.length} field(s) to ${result.className}');
+      print('Added ${fields.length} field(s) to ${result.className}');
     } else {
-      print('❌ ${result.error}');
+      print('${result.error}');
       exit(1);
     }
   }
@@ -291,7 +293,8 @@ class _ListCommand extends Command<void> {
       return;
     }
 
-    print('📂 Zorphy Entities in $dir:\n');
+    print('Zorphy Entities in $dir:');
+    print('');
 
     await for (final entity in entityDir.list()) {
       if (entity is Directory) {
@@ -299,11 +302,11 @@ class _ListCommand extends Command<void> {
         final dartFile = File(p.join(entity.path, '$entityName.dart'));
         if (await dartFile.exists()) {
           final content = await dartFile.readAsString();
-          print('  📄 $entityName');
+          print('  $entityName');
           if (content.contains('generateJson: true'))
-            print('     ✓ JSON support');
+            print('     - JSON support');
           if (content.contains('abstract class \$\$'))
-            print('     🔒 Sealed class');
+            print('     - Sealed class');
         }
       }
     }
@@ -452,9 +455,9 @@ class _FromJsonCommand extends Command<void> {
     final result = await creator.create(config);
 
     if (result.isSuccess) {
-      print('✓ Created entity: ${result.filePath}');
+      print('Created entity: ${result.filePath}');
     } else {
-      print('❌ ${result.error}');
+      print('${result.error}');
       exit(1);
     }
   }
@@ -704,6 +707,83 @@ class _SelfUpdateCommand extends Command<void> {
     final updateResult = await checker.performUpdateAndVerify();
     print(updateResult);
     if (!updateResult.success) {
+      exit(1);
+    }
+  }
+}
+
+
+class _DoctorCommand extends Command<void> {
+  @override
+  String get name => 'doctor';
+
+  @override
+  String get description =>
+      'Diagnose and fix stale/corrupt generated .zorphy.dart files by deleting them and regenerating cleanly';
+
+  _DoctorCommand() {
+    argParser.addOption(
+      'dir',
+      abbr: 'd',
+      help: 'Project directory (default: current directory)',
+    );
+    argParser.addMultiOption(
+      'source',
+      help: 'Additional source directories to scan (default: lib)',
+    );
+    argParser.addFlag(
+      'dry-run',
+      negatable: false,
+      help: 'Preview files to delete without making changes',
+    );
+    argParser.addFlag(
+      'json',
+      negatable: false,
+      help: 'Output results as JSON',
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final dir = argResults!['dir'] as String? ?? Directory.current.path;
+    final extraSources = (argResults!['source'] as List<String>?) ?? [];
+    final sourceDirs = ['lib', ...extraSources];
+    final dryRun = argResults!['dry-run'] as bool;
+    final asJson = argResults!['json'] as bool;
+
+    final projectDir = Directory(dir);
+    if (!projectDir.existsSync()) {
+      if (asJson) {
+        final errorOutput = {
+          'projectDir': dir,
+          'dryRun': dryRun,
+          'deletedCount': 0,
+          'deletedFiles': <String>[],
+          'regeneratedCount': 0,
+          'remainingInvalidTypeFiles': <String>[],
+          'health': 'unhealthy',
+          'error': 'Directory not found: $dir',
+        };
+        print(const JsonEncoder.withIndent('  ').convert(errorOutput));
+      } else {
+        print('Error: Directory not found: $dir');
+      }
+      exit(1);
+    }
+
+    final service = DoctorService(
+      projectDir: dir,
+      sourceDirs: sourceDirs,
+    );
+    final result = await service.run(dryRun: dryRun);
+
+    if (asJson) {
+      print(const JsonEncoder.withIndent('  ').convert(result.toJson()));
+    } else {
+      print(result);
+    }
+
+    if (result.health == DoctorHealth.unhealthy) {
       exit(1);
     }
   }

--- a/zorphy/lib/src/cli/models/doctor_result.dart
+++ b/zorphy/lib/src/cli/models/doctor_result.dart
@@ -1,0 +1,128 @@
+/// Result models for the zorphy doctor command.
+library;
+
+/// Overall health status after running doctor.
+enum DoctorHealth {
+  /// No issues — all generated files are clean.
+  healthy,
+
+  /// Some warnings (e.g. InvalidType remnants) but regeneration succeeded.
+  warnings,
+
+  /// Regeneration failed or critical problems remain.
+  unhealthy,
+}
+
+/// Aggregated result of the doctor command.
+class DoctorResult {
+  /// Files that were (or would be) deleted.
+  final List<String> deletedFiles;
+
+  /// Number of .zorphy.dart files regenerated after build_runner.
+  final int regeneratedCount;
+
+  /// Files still containing 'InvalidType' after regeneration.
+  final List<String> remainingInvalidTypeFiles;
+
+  /// Whether this was a dry-run (no actual deletion or regeneration).
+  final bool dryRun;
+
+  /// The project directory that was doctored.
+  final String projectDir;
+
+  /// Output from the build_runner process (stdout).
+  final String buildOutput;
+
+  /// Exit code of the build_runner process, or null if not run.
+  final int? buildExitCode;
+
+  const DoctorResult({
+    this.deletedFiles = const [],
+    this.regeneratedCount = 0,
+    this.remainingInvalidTypeFiles = const [],
+    this.dryRun = false,
+    required this.projectDir,
+    this.buildOutput = '',
+    this.buildExitCode,
+  });
+
+  /// Number of files deleted.
+  int get deletedCount => deletedFiles.length;
+
+  /// Whether any InvalidType occurrences remain.
+  bool get hasInvalidType => remainingInvalidTypeFiles.isNotEmpty;
+
+  /// Overall health assessment.
+  DoctorHealth get health {
+    if (buildExitCode != null && buildExitCode != 0) {
+      return DoctorHealth.unhealthy;
+    }
+    if (hasInvalidType) {
+      return DoctorHealth.warnings;
+    }
+    return DoctorHealth.healthy;
+  }
+
+  @override
+  String toString() {
+    final buf = StringBuffer();
+    buf.writeln('Zorphy Doctor Report');
+    buf.writeln('Directory: $projectDir');
+    if (dryRun) {
+      buf.writeln('Mode: dry-run (no changes made)');
+    }
+    buf.writeln('');
+
+    buf.writeln('Deleted $deletedCount stale .zorphy.dart file(s)');
+    if (deletedFiles.isNotEmpty) {
+      for (final f in deletedFiles) {
+        buf.writeln('  - $f');
+      }
+    }
+    buf.writeln('');
+
+    if (dryRun) {
+      buf.writeln(
+          'Would run: dart run build_runner build --delete-conflicting-outputs');
+    } else {
+      buf.writeln(
+          'Build runner exited with code ${buildExitCode ?? "not run"}');
+      buf.writeln('Regenerated $regeneratedCount .zorphy.dart file(s)');
+    }
+    buf.writeln('');
+
+    if (hasInvalidType) {
+      buf.writeln(
+          'WARNING: InvalidType still found in ${remainingInvalidTypeFiles.length} file(s):');
+      for (final f in remainingInvalidTypeFiles) {
+        buf.writeln('  - $f');
+      }
+      buf.writeln('');
+    }
+
+    switch (health) {
+      case DoctorHealth.healthy:
+        buf.writeln('Project health: healthy');
+      case DoctorHealth.warnings:
+        buf.writeln('Project health: warnings (InvalidType remnants)');
+      case DoctorHealth.unhealthy:
+        buf.writeln('Project health: unhealthy (build_runner failed)');
+    }
+
+    return buf.toString();
+  }
+
+  /// JSON-serializable map for --json output.
+  Map<String, dynamic> toJson() {
+    return {
+      'projectDir': projectDir,
+      'dryRun': dryRun,
+      'deletedCount': deletedCount,
+      'deletedFiles': deletedFiles,
+      'regeneratedCount': regeneratedCount,
+      'remainingInvalidTypeFiles': remainingInvalidTypeFiles,
+      'health': health.name,
+      'buildExitCode': buildExitCode,
+    };
+  }
+}

--- a/zorphy/lib/src/cli/services/doctor_service.dart
+++ b/zorphy/lib/src/cli/services/doctor_service.dart
@@ -1,0 +1,211 @@
+/// Doctor service for zorphy.
+///
+/// Scans a Dart project for stale .zorphy.dart generated part files,
+/// optionally deletes them, runs build_runner for clean regeneration,
+/// and reports on project health (including InvalidType remnants).
+///
+/// Designed with injectable dependencies (file system, process runner)
+/// for testability without heavyweight mocking.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import '../models/doctor_result.dart';
+
+/// Functional type for listing .zorphy.dart files recursively.
+/// Returns absolute paths of all matching files.
+typedef FindGeneratedFilesFunction = List<String> Function(
+  String projectDir, {
+  List<String> sourceDirs,
+});
+
+/// Functional type for deleting a single file.
+/// Returns true if the file was successfully deleted.
+typedef DeleteFileFunction = bool Function(String path);
+
+/// Functional type for running a subprocess (named differently to
+/// avoid export collision with version_checker's RunProcessFunction).
+typedef DoctorProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> args, {
+  String? workingDirectory,
+});
+
+/// Functional type for reading a file's content.
+typedef ReadFileFunction = String Function(String path);
+
+/// Service that performs the "doctor" workflow:
+/// 1. Scan for *.zorphy.dart files
+/// 2. Delete them (or preview with dry-run)
+/// 3. Run build_runner for clean regeneration
+/// 4. Report counts and InvalidType occurrences
+class DoctorService {
+  /// Root directory of the project.
+  final String projectDir;
+
+  /// Source directories to scan (relative to projectDir).
+  final List<String> sourceDirs;
+
+  /// Overrideable file finder for testing.
+  final FindGeneratedFilesFunction? findFiles;
+
+  /// Overrideable file deleter for testing.
+  final DeleteFileFunction? deleteFile;
+
+  /// Overrideable process runner for testing.
+  final DoctorProcessRunner? processRunner;
+
+  /// Overrideable file reader for testing.
+  final ReadFileFunction? readFile;
+
+  DoctorService({
+    required this.projectDir,
+    List<String>? sourceDirs,
+    this.findFiles,
+    this.deleteFile,
+    this.processRunner,
+    this.readFile,
+  }) : sourceDirs = sourceDirs ?? const ['lib'];
+
+  /// Run the full doctor workflow.
+  ///
+  /// If [dryRun] is true, scans and reports but does not delete or regenerate.
+  Future<DoctorResult> run({bool dryRun = false}) async {
+    final dirs = sourceDirs;
+
+    // Step 1: Find all .zorphy.dart files
+    final generatedFiles =
+        _doFindFiles(projectDir, sourceDirs: dirs);
+
+    // Step 2: Delete files (unless dry-run)
+    final deletedFiles = <String>[];
+    if (dryRun) {
+      deletedFiles.addAll(generatedFiles);
+    } else {
+      for (final filePath in generatedFiles) {
+        if (_doDeleteFile(filePath)) {
+          deletedFiles.add(filePath);
+        }
+      }
+    }
+
+    // Step 3: Run build_runner (unless dry-run)
+    var buildOutput = '';
+    int? buildExitCode;
+    if (!dryRun) {
+      final result = await _doRunProcess(
+        'dart',
+        ['run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+        workingDirectory: projectDir,
+      );
+      buildOutput = '${result.stdout}\n${result.stderr}';
+      buildExitCode = result.exitCode;
+    }
+
+    // Step 4: Count regenerated files and check for InvalidType
+    int regeneratedCount = 0;
+    final remainingInvalidTypeFiles = <String>[];
+
+    final filesAfterBuild =
+        _doFindFiles(projectDir, sourceDirs: dirs);
+
+    if (!dryRun) {
+      // Count files that exist now but weren't in the original set
+      // (or simply count all current .zorphy.dart files as regenerated)
+      regeneratedCount = filesAfterBuild.length;
+
+      // Scan for InvalidType in the regenerated files
+      for (final filePath in filesAfterBuild) {
+        try {
+          final content = _doReadFile(filePath);
+          if (content.contains('InvalidType')) {
+            remainingInvalidTypeFiles.add(filePath);
+          }
+        } catch (_) {
+          // If we can't read a file, skip it
+        }
+      }
+    }
+
+    return DoctorResult(
+      deletedFiles: deletedFiles,
+      regeneratedCount: regeneratedCount,
+      remainingInvalidTypeFiles: remainingInvalidTypeFiles,
+      dryRun: dryRun,
+      projectDir: projectDir,
+      buildOutput: buildOutput,
+      buildExitCode: buildExitCode,
+    );
+  }
+
+  /// Find all .zorphy.dart files in the project.
+  List<String> _doFindFiles(
+    String dir, {
+    List<String> sourceDirs = const ['lib'],
+  }) {
+    if (findFiles != null) {
+      return findFiles!(dir, sourceDirs: sourceDirs);
+    }
+
+    final results = <String>[];
+    for (final sourceDir in sourceDirs) {
+      final absDir = p.join(dir, sourceDir);
+      final dirEntity = Directory(absDir);
+      if (!dirEntity.existsSync()) continue;
+
+      for (final entity
+          in dirEntity.listSync(recursive: true, followLinks: false)) {
+        if (entity is File && entity.path.endsWith('.zorphy.dart')) {
+          results.add(entity.path);
+        }
+      }
+    }
+    return results;
+  }
+
+  /// Delete a single file. Returns true on success.
+  bool _doDeleteFile(String path) {
+    if (deleteFile != null) {
+      return deleteFile!(path);
+    }
+    try {
+      final file = File(path);
+      if (file.existsSync()) {
+        file.deleteSync();
+        return true;
+      }
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Run a subprocess.
+  Future<ProcessResult> _doRunProcess(
+    String executable,
+    List<String> args, {
+    String? workingDirectory,
+  }) async {
+    if (processRunner != null) {
+      return processRunner!(executable, args,
+          workingDirectory: workingDirectory);
+    }
+
+    return Process.run(
+      executable,
+      args,
+      workingDirectory: workingDirectory,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+  }
+
+  /// Read file content as string.
+  String _doReadFile(String path) {
+    if (readFile != null) {
+      return readFile!(path);
+    }
+    return File(path).readAsStringSync();
+  }
+}

--- a/zorphy/lib/zorphy_cli.dart
+++ b/zorphy/lib/zorphy_cli.dart
@@ -6,6 +6,8 @@ export 'src/cli/entity_creator.dart';
 export 'src/cli/models/entity_config.dart';
 export 'src/cli/models/update_result.dart';
 export 'src/cli/models/validation_result.dart';
+export 'src/cli/models/doctor_result.dart';
 export 'src/cli/services/project_validator.dart';
 export 'src/cli/services/version_checker.dart';
+export 'src/cli/services/doctor_service.dart';
 export 'src/cli/utils/naming_utils.dart';

--- a/zorphy/test/doctor_test.dart
+++ b/zorphy/test/doctor_test.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:zorphy/zorphy_cli.dart';
+
+void main() {
+  group('DoctorService', () {
+    late Directory tempDir;
+    late String tempPath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('zorphy_doctor_test_');
+      tempPath = tempDir.path;
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('dry-run finds .zorphy.dart files without deleting', () async {
+      final libDir = Directory('$tempPath/lib')..createSync(recursive: true);
+      File('${libDir.path}/user.zorphy.dart').createSync();
+      File('${libDir.path}/product.zorphy.dart').createSync();
+      File('${libDir.path}/other.txt').createSync();
+
+      final service = DoctorService(projectDir: tempPath);
+      final result = await service.run(dryRun: true);
+
+      expect(result.dryRun, isTrue);
+      expect(result.deletedCount, equals(2));
+      expect(result.deletedFiles, containsAll([
+        '${libDir.path}/user.zorphy.dart',
+        '${libDir.path}/product.zorphy.dart',
+      ]));
+      expect(result.regeneratedCount, equals(0));
+      expect(result.buildExitCode, isNull);
+
+      // Files should still exist
+      expect(File('${libDir.path}/user.zorphy.dart').existsSync(), isTrue);
+      expect(File('${libDir.path}/product.zorphy.dart').existsSync(), isTrue);
+    });
+
+    test('dry-run with --json produces valid JSON', () async {
+      final libDir = Directory('$tempPath/lib')..createSync(recursive: true);
+      File('${libDir.path}/user.zorphy.dart').createSync();
+
+      final service = DoctorService(projectDir: tempPath);
+      final result = await service.run(dryRun: true);
+
+      final json = jsonDecode(jsonEncode(result.toJson())) as Map<String, dynamic>;
+      expect(json['dryRun'], isTrue);
+      expect(json['deletedCount'], equals(1));
+      expect(json['health'], equals('healthy'));
+    });
+
+    test('deletes .zorphy.dart files and runs build_runner', () async {
+      final libDir = Directory('$tempPath/lib')..createSync(recursive: true);
+      File('${libDir.path}/user.zorphy.dart').createSync();
+
+      var processCalled = false;
+      String? receivedWorkingDir;
+
+      final service = DoctorService(
+        projectDir: tempPath,
+        processRunner: (executable, args, {workingDirectory}) async {
+          processCalled = true;
+          receivedWorkingDir = workingDirectory;
+          expect(executable, equals('dart'));
+          expect(args, containsAll([
+            'run',
+            'build_runner',
+            'build',
+            '--delete-conflicting-outputs',
+          ]));
+          return ProcessResult(0, 0, 'Build succeeded', '');
+        },
+      );
+
+      final result = await service.run(dryRun: false);
+
+      expect(result.dryRun, isFalse);
+      expect(result.deletedCount, equals(1));
+      expect(processCalled, isTrue);
+      expect(receivedWorkingDir, equals(tempPath));
+      expect(result.buildExitCode, equals(0));
+      expect(result.health, equals(DoctorHealth.healthy));
+
+      // File should be deleted
+      expect(File('${libDir.path}/user.zorphy.dart').existsSync(), isFalse);
+    });
+
+    test('detects InvalidType in regenerated files', () async {
+      final libDir = Directory('$tempPath/lib')..createSync(recursive: true);
+      File('${libDir.path}/user.zorphy.dart').createSync();
+
+      final service = DoctorService(
+        projectDir: tempPath,
+        processRunner: (executable, args, {workingDirectory}) async {
+          // Simulate build_runner recreating the file with InvalidType
+          File('${libDir.path}/user.zorphy.dart')
+            ..createSync()
+            ..writeAsStringSync(
+              'class User { InvalidType? field; }',
+            );
+          return ProcessResult(0, 0, 'Build succeeded', '');
+        },
+      );
+
+      final result = await service.run(dryRun: false);
+
+      expect(result.regeneratedCount, equals(1));
+      expect(result.hasInvalidType, isTrue);
+      expect(result.remainingInvalidTypeFiles.length, equals(1));
+      expect(result.health, equals(DoctorHealth.warnings));
+    });
+
+    test('reports unhealthy when build_runner fails', () async {
+      final libDir = Directory('$tempPath/lib')..createSync(recursive: true);
+      File('${libDir.path}/user.zorphy.dart').createSync();
+
+      final service = DoctorService(
+        projectDir: tempPath,
+        processRunner: (executable, args, {workingDirectory}) async {
+          return ProcessResult(1, 1, '', 'Build failed');
+        },
+      );
+
+      final result = await service.run(dryRun: false);
+
+      expect(result.buildExitCode, equals(1));
+      expect(result.health, equals(DoctorHealth.unhealthy));
+    });
+
+    test('scans multiple source directories', () async {
+      Directory('$tempPath/lib').createSync(recursive: true);
+      Directory('$tempPath/test').createSync(recursive: true);
+      File('$tempPath/lib/user.zorphy.dart').createSync();
+      File('$tempPath/test/widget.zorphy.dart').createSync();
+
+      final service = DoctorService(
+        projectDir: tempPath,
+        sourceDirs: ['lib', 'test'],
+      );
+      final result = await service.run(dryRun: true);
+
+      expect(result.deletedCount, equals(2));
+    });
+
+    test('handles empty project with no generated files', () async {
+      Directory('$tempPath/lib').createSync(recursive: true);
+
+      final service = DoctorService(projectDir: tempPath);
+      final result = await service.run(dryRun: true);
+
+      expect(result.deletedCount, equals(0));
+      expect(result.health, equals(DoctorHealth.healthy));
+    });
+
+    test('handles missing source directories gracefully', () async {
+      final service = DoctorService(
+        projectDir: tempPath,
+        sourceDirs: ['lib', 'nonexistent'],
+      );
+      final result = await service.run(dryRun: true);
+
+      expect(result.deletedCount, equals(0));
+    });
+  });
+
+  group('DoctorResult', () {
+    test('toString formats healthy result correctly', () {
+      final result = DoctorResult(
+        projectDir: '/tmp/test',
+        deletedFiles: ['/tmp/test/lib/a.zorphy.dart'],
+        regeneratedCount: 1,
+        buildExitCode: 0,
+      );
+
+      final output = result.toString();
+      expect(output, contains('Zorphy Doctor Report'));
+      expect(output, contains('Deleted 1 stale .zorphy.dart file(s)'));
+      expect(output, contains('Regenerated 1 .zorphy.dart file(s)'));
+      expect(output, contains('Project health: healthy'));
+    });
+
+    test('toString formats dry-run result correctly', () {
+      final result = DoctorResult(
+        projectDir: '/tmp/test',
+        deletedFiles: ['/tmp/test/lib/a.zorphy.dart'],
+        dryRun: true,
+      );
+
+      final output = result.toString();
+      expect(output, contains('dry-run (no changes made)'));
+      expect(output,
+          contains('Would run: dart run build_runner build --delete-conflicting-outputs'));
+    });
+
+    test('toString formats warnings result correctly', () {
+      final result = DoctorResult(
+        projectDir: '/tmp/test',
+        regeneratedCount: 2,
+        remainingInvalidTypeFiles: ['/tmp/test/lib/a.zorphy.dart'],
+        buildExitCode: 0,
+      );
+
+      final output = result.toString();
+      expect(output, contains('WARNING: InvalidType still found'));
+      expect(output, contains('Project health: warnings'));
+    });
+
+    test('toString formats unhealthy result correctly', () {
+      final result = DoctorResult(
+        projectDir: '/tmp/test',
+        buildExitCode: 1,
+      );
+
+      final output = result.toString();
+      expect(output, contains('Project health: unhealthy'));
+    });
+
+    test('toJson contains all fields', () {
+      final result = DoctorResult(
+        projectDir: '/tmp/test',
+        deletedFiles: ['a.dart', 'b.dart'],
+        regeneratedCount: 2,
+        remainingInvalidTypeFiles: ['a.dart'],
+        dryRun: true,
+        buildExitCode: 0,
+      );
+
+      final json = result.toJson();
+      expect(json['projectDir'], equals('/tmp/test'));
+      expect(json['dryRun'], isTrue);
+      expect(json['deletedCount'], equals(2));
+      expect(json['regeneratedCount'], equals(2));
+      expect(json['health'], equals('warnings'));
+      expect(json['buildExitCode'], equals(0));
+    });
+
+    test('health is healthy when no issues', () {
+      final result = DoctorResult(
+        projectDir: '/tmp',
+        buildExitCode: 0,
+      );
+      expect(result.health, equals(DoctorHealth.healthy));
+    });
+
+    test('health is warnings when InvalidType remains', () {
+      final result = DoctorResult(
+        projectDir: '/tmp',
+        buildExitCode: 0,
+        remainingInvalidTypeFiles: ['a.dart'],
+      );
+      expect(result.health, equals(DoctorHealth.warnings));
+    });
+
+    test('health is unhealthy when build fails', () {
+      final result = DoctorResult(
+        projectDir: '/tmp',
+        buildExitCode: 1,
+      );
+      expect(result.health, equals(DoctorHealth.unhealthy));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `doctor` command to diagnose and repair generated files.
  * Supports dry-run previews, JSON output, custom source directories, and clear status reporting.
  * Automatically removes stale generated files and regenerates them when needed.
  * Reports remaining issues and returns an appropriate command status.

* **Style**
  * Simplified CLI output by removing emoji prefixes and using plain-text labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->