### PR TITLE
feat(cli): custom JSON wire names via 'name:type:json=<wire>' (arrrrny/zuraffa#303)

### DIFF
--- a/zorphy/lib/src/cli/entity_creator.dart
+++ b/zorphy/lib/src/cli/entity_creator.dart
@@ -324,6 +324,9 @@ class EntityCreator {
     final fieldBuffer = StringBuffer();
     for (final field in fields) {
       fieldBuffer.writeln();
+      if (field.jsonName != null) {
+        fieldBuffer.writeln("  @JsonKey(name: '${field.jsonName}')");
+      }
       fieldBuffer.writeln('  ${field.fullType} get ${field.name};');
     }
 

--- a/zorphy/lib/src/cli/generators/entity_template_generator.dart
+++ b/zorphy/lib/src/cli/generators/entity_template_generator.dart
@@ -98,9 +98,7 @@ class EntityTemplateGenerator {
     }
     buffer.writeln();
 
-    for (final field in config.fields) {
-      buffer.writeln('  ${field.fullType} get ${field.name};');
-    }
+    _writeFields(buffer, config.fields);
 
     buffer.writeln('}');
     buffer.writeln();
@@ -134,9 +132,7 @@ class EntityTemplateGenerator {
 
     if (config.fields.isNotEmpty) {
       buffer.writeln();
-      for (final field in config.fields) {
-        buffer.writeln('  ${field.fullType} get ${field.name};');
-      }
+      _writeFields(buffer, config.fields);
     }
 
     buffer.writeln('}');
@@ -188,14 +184,24 @@ class EntityTemplateGenerator {
 
     if (fields.isNotEmpty) {
       buffer.writeln();
-      for (final field in fields) {
-        buffer.writeln('  ${field.fullType} get ${field.name};');
-      }
+      _writeFields(buffer, fields);
     }
 
     buffer.writeln('}');
     buffer.writeln();
 
     return buffer.toString();
+  }
+
+  /// Writes the getter declarations for [fields], emitting an
+  /// `@JsonKey(name: ...)` annotation above a getter when the field's
+  /// [FieldDefinition.jsonName] differs from its Dart [FieldDefinition.name].
+  static void _writeFields(StringBuffer buffer, List<FieldDefinition> fields) {
+    for (final field in fields) {
+      if (field.jsonName != null) {
+        buffer.writeln("  @JsonKey(name: '${field.jsonName}')");
+      }
+      buffer.writeln('  ${field.fullType} get ${field.name};');
+    }
   }
 }

--- a/zorphy/lib/src/cli/models/entity_config.dart
+++ b/zorphy/lib/src/cli/models/entity_config.dart
@@ -99,19 +99,35 @@ class FieldDefinition {
   final String type;
   final bool nullable;
 
+  /// Optional JSON wire name for the field, when it differs from the Dart
+  /// [name]. Needed for GraphQL fields whose wire name is a Dart-reserved
+  /// keyword (`in`, `required`) or that legitimately differ on the wire
+  /// (Vendure's `_and` / `_or` filter operators). When set, the generated
+  /// source getter carries `@JsonKey(name: '<jsonName>')`, which the zorphy
+  /// builder already propagates into the concrete class and json_serializable
+  /// output.
+  final String? jsonName;
+
   const FieldDefinition({
     required this.name,
     required this.type,
     this.nullable = false,
+    this.jsonName,
   });
 
   String get fullType => nullable && !type.endsWith('?') ? '$type?' : type;
 
+  /// Parses a field definition in one of two forms:
+  ///
+  /// - `name:type` (e.g. `id:String`, `note:String?`, `countries:List<Country>`)
+  /// - `name:type:json=<wireName>` (e.g. `in_:String:json=in`,
+  ///   `and:ProductFilterParameter:json=_and`)
   factory FieldDefinition.parse(String definition) {
     final parts = definition.split(':');
-    if (parts.length != 2) {
+    if (parts.length < 2 || parts.length > 3) {
       throw ArgumentError(
-        'Invalid field format: "$definition". Expected "name:type"',
+        'Invalid field format: "$definition". '
+        'Expected "name:type" or "name:type:json=<wireName>"',
       );
     }
     final fieldName = parts[0].trim();
@@ -120,18 +136,41 @@ class FieldDefinition {
     if (isNullable) {
       fieldType = fieldType.substring(0, fieldType.length - 1);
     }
+    String? jsonName;
+    if (parts.length == 3) {
+      final meta = parts[2].trim();
+      const prefix = 'json=';
+      if (!meta.startsWith(prefix)) {
+        throw ArgumentError(
+          'Invalid field meta: "$meta". Expected "json=<wireName>"',
+        );
+      }
+      jsonName = meta.substring(prefix.length).trim();
+      if (jsonName.isEmpty) {
+        throw ArgumentError(
+          'Invalid field meta: "$meta". "json=" requires a wire name',
+        );
+      }
+    }
     return FieldDefinition(
       name: fieldName,
       type: fieldType,
       nullable: isNullable,
+      jsonName: jsonName,
     );
   }
 
-  FieldDefinition copyWith({String? name, String? type, bool? nullable}) {
+  FieldDefinition copyWith({
+    String? name,
+    String? type,
+    bool? nullable,
+    String? jsonName,
+  }) {
     return FieldDefinition(
       name: name ?? this.name,
       type: type ?? this.type,
       nullable: nullable ?? this.nullable,
+      jsonName: jsonName ?? this.jsonName,
     );
   }
 }

--- a/zorphy/test/field_definition_test.dart
+++ b/zorphy/test/field_definition_test.dart
@@ -1,0 +1,81 @@
+import 'package:test/test.dart';
+import 'package:zorphy/zorphy.dart';
+
+void main() {
+  group('FieldDefinition.parse', () {
+    test('parses plain name:type', () {
+      final f = FieldDefinition.parse('id:String');
+      expect(f.name, 'id');
+      expect(f.type, 'String');
+      expect(f.nullable, isFalse);
+      expect(f.jsonName, isNull);
+      expect(f.fullType, 'String');
+    });
+
+    test('parses nullable type', () {
+      final f = FieldDefinition.parse('note:String?');
+      expect(f.name, 'note');
+      expect(f.type, 'String');
+      expect(f.nullable, isTrue);
+      expect(f.fullType, 'String?');
+    });
+
+    test('parses generic list type', () {
+      final f = FieldDefinition.parse('countries:List<Country>');
+      expect(f.name, 'countries');
+      expect(f.type, 'List<Country>');
+      expect(f.fullType, 'List<Country>');
+    });
+
+    test('parses name:type:json=<wireName>', () {
+      final f = FieldDefinition.parse('in_:String:json=in');
+      expect(f.name, 'in_');
+      expect(f.type, 'String');
+      expect(f.jsonName, 'in');
+    });
+
+    test('parses wire name for GraphQL _and operator', () {
+      final f = FieldDefinition.parse(
+        'and:ProductFilterParameter:json=_and',
+      );
+      expect(f.name, 'and');
+      expect(f.type, 'ProductFilterParameter');
+      expect(f.jsonName, '_and');
+    });
+
+    test('rejects malformed meta segment', () {
+      expect(
+        () => FieldDefinition.parse('in_:String:wire=in'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects empty json= wire name', () {
+      expect(
+        () => FieldDefinition.parse('in_:String:json='),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects definitions with too many parts', () {
+      expect(
+        () => FieldDefinition.parse('a:String:json=x:extra'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects definitions with a single part', () {
+      expect(() => FieldDefinition.parse('id'), throwsArgumentError);
+    });
+  });
+
+  group('FieldDefinition.copyWith', () {
+    test('preserves jsonName when not overridden', () {
+      final f = FieldDefinition.parse('in_:String:json=in');
+      final copy = f.copyWith(type: 'int');
+      expect(copy.name, 'in_');
+      expect(copy.type, 'int');
+      expect(copy.jsonName, 'in');
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds an optional **JSON wire name** to entity fields so generated entities can
express GraphQL fields whose wire name differs from the Dart identifier.

**New field syntax** (applies to `zfa entity create`, `zfa entity add-field`,
and subtype generation):

```
--field 'in_:String:json=in'                          # Dart keyword escape
--field 'and:ProductFilterParameter:json=_and'         # Vendure _and/_or operators
--field 'required_:Boolean:json=required'              # Dart keyword escape
```

When `json=<wireName>` is present, the generated source getter carries
`@JsonKey(name: '<wireName>')`. The zorphy builder already propagates
`@JsonKey` from source getters into the concrete class (`.zorphy.dart`) and
json_serializable output (`.g.dart`) — verified end-to-end:

```dart
// id_operators2.g.dart (generated)
Map<String, dynamic> _$IdOperators2ToJson(IdOperators2 instance) =>
    <String, dynamic>{'in': instance.in_, 'eq': instance.eq};
```

## Why

Blocks the vendure-flutter-sdk zfa-driven rewrite (arrrrny/zuraffa#303):
11 of 179 Vendure entities (19 fields) need wire names that differ from Dart
names — `_and`/`_or` on 9 `*FilterParameter` input types, `in` on
`IdOperators`/`StringOperators`, `required` on `ConfigArgDefinition`. Without
this, filter queries serialize with the wrong keys and Vendure rejects them —
a silent wire-contract break. Hand-writing the 11 entities would violate the
Zuraffa Obstacle Protocol, so the toolchain is fixed instead.

## Changes

- `zorphy/lib/src/cli/models/entity_config.dart` — `FieldDefinition.jsonName` +
  extended `parse()` (`name:type` or `name:type:json=<wire>`), copyWith.
- `zorphy/lib/src/cli/generators/entity_template_generator.dart` — emit
  `@JsonKey(name: ...)` in create/subtype templates (shared `_writeFields`).
- `zorphy/lib/src/cli/entity_creator.dart` — same emission in the add-field
  insertion path.
- `zorphy/test/field_definition_test.dart` — parse/copyWith unit tests (10).

## Verification

- `dart analyze lib/src/cli/` — clean.
- `dart test test/field_definition_test.dart` — 10/10 pass; full `basic_test` +
  `validate_test` pass.
- End-to-end via `zfa entity create` + `zfa build` in a spike project:
  wire key `'in'` / `'_and'` / `'_or'` confirmed in `.g.dart`, zero build errors.

Fixes arrrrny/zuraffa#303 (cross-repo; will not auto-close — maintainer closes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom JSON wire names in field definitions using `json=<wireName>` metadata.
  * Generated entities now include JSON mapping annotations when Dart field names differ from their JSON names.

* **Bug Fixes**
  * Improved validation and handling of malformed or empty JSON name metadata.

* **Tests**
  * Added coverage for JSON name parsing, nullable and generic fields, invalid input, and field copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->