### PR TITLE
fix(cli): plain type (no $ prefix) for hand-written non-Zorphy field refs (#310)

### DIFF
--- a/zorphy/lib/src/cli/services/field_normalizer.dart
+++ b/zorphy/lib/src/cli/services/field_normalizer.dart
@@ -70,14 +70,21 @@ class FieldNormalizer {
     final entityDir = Directory(p.join(baseOutputDir, entitySnakeName));
     final entityFile = File(p.join(entityDir.path, '$entitySnakeName.dart'));
 
-    if (entityFile.existsSync()) {
-      try {
-        final content = entityFile.readAsStringSync();
-        if (content.contains('abstract class \$\$$typeName')) {
-          return '\$\$';
-        }
-      } catch (_) {}
-    }
-    return '\$';
+    if (!entityFile.existsSync()) return '';
+
+    try {
+      final content = entityFile.readAsStringSync();
+      if (RegExp('abstract class \\\$\\\$$typeName\\b').hasMatch(content)) {
+        return '\$\$';
+      }
+      if (RegExp('abstract class \\\$' + typeName + r'\b').hasMatch(content)) {
+        return '\$';
+      }
+    } catch (_) {}
+
+    // The referenced file exists but declares no Zorphy abstract — e.g. a
+    // hand-written plain/sealed class (issue #310). Emit the plain type so
+    // the concrete class and json_serializable resolve it via the import.
+    return '';
   }
 }


### PR DESCRIPTION
## What

Fixes `zfa entity create` emitting `$X` (undefined identifier → `InvalidType`)
for fields whose type is a **hand-written plain/sealed class** in another file
(arrrrny/zuraffa#310).

`FieldNormalizer._determinePrefix` now inspects the referenced entity file:

- `abstract class $$X` → `$$` prefix (sealed Zorphy base)
- `abstract class $X` → `$` prefix (Zorphy entity)
- otherwise (plain/sealed hand-written class) → **no prefix** — the plain type
  is emitted and resolves via the import

## Why

Mixed projects (generated Zorphy entities + hand-written glue classes) cannot
build: `SearchResult` (generated) references `SearchResultPrice` (hand-written
sealed union dispatcher with a `runtimeType`-based `fromJson`). The analyzer
cannot resolve `$SearchResultPrice` (no such identifier), so the concrete class
got `final InvalidType price;` and json_serializable failed. Blocks the
vendure-flutter-sdk zfa-driven rewrite (1 entity, 2 fields).

## Verification

- Spike: hand-written `sealed class SearchResultPrice` (with `fromJson`) +
  `zfa entity create -n SearchResult --field price:SearchResultPrice? --field
  priceWithTax:SearchResultPrice?` + `zfa build` → source
  `SearchResultPrice? get price;`, concrete `final SearchResultPrice? price;`,
  `.g.dart` `SearchResultPrice.fromJson(...)`, **zero InvalidType**, build green.
- Zorphy entity refs unchanged: `Address → Country` still generates
  `$Country get country;` + `final Country country;`.

Fixes arrrrny/zuraffa#310.
