### PR TITLE
fix(cli): support !Type external field marker — no $ prefix, no bogus imports (#349)

### DIFF
--- a/zorphy/lib/src/cli/models/entity_config.dart
+++ b/zorphy/lib/src/cli/models/entity_config.dart
@@ -126,18 +126,31 @@ class FieldDefinition {
   /// output.
   final String? jsonName;
 
+  /// True when the type was written with the `!` prefix (e.g. `url:!WebUri?`),
+  /// marking it as EXTERNAL — a type that lives outside the entity tree
+  /// (plugin wrappers like `WebUri`, SDK classes, ...). External types are
+  /// kept as-is: no `$` prefix is added by `FieldNormalizer`, no entity/enum
+  /// import is resolved by `ImportResolver`, and on-disk validation is
+  /// skipped. The user is responsible for importing the type in the
+  /// generated entity source.
+  final bool isExternal;
+
   const FieldDefinition({
     required this.name,
     required this.type,
     this.nullable = false,
     this.jsonName,
+    this.isExternal = false,
   });
 
   String get fullType => nullable && !type.endsWith('?') ? '$type?' : type;
 
-  /// Parses a field definition in one of two forms:
+  /// Parses a field definition in one of three forms:
   ///
   /// - `name:type` (e.g. `id:String`, `note:String?`, `countries:List<Country>`)
+  /// - `name:!type` (e.g. `url:!WebUri?`) — external (non-entity, non-enum)
+  ///   type, kept as-is with no `$` prefix, no import resolution, no
+  ///   on-disk validation (see [isExternal]).
   /// - `name:type:json=<wireName>` (e.g. `in_:String:json=in`,
   ///   `and:ProductFilterParameter:json=_and`)
   factory FieldDefinition.parse(String definition) {
@@ -150,6 +163,16 @@ class FieldDefinition {
     }
     final fieldName = parts[0].trim();
     var fieldType = parts[1].trim();
+    final isExternal = fieldType.startsWith('!');
+    if (isExternal) {
+      fieldType = fieldType.substring(1);
+      if (fieldType.isEmpty) {
+        throw ArgumentError(
+          'Invalid field format: "$definition". '
+          'The "!" prefix requires a type name after it.',
+        );
+      }
+    }
     final isNullable = fieldType.endsWith('?');
     if (isNullable) {
       fieldType = fieldType.substring(0, fieldType.length - 1);
@@ -175,6 +198,7 @@ class FieldDefinition {
       type: fieldType,
       nullable: isNullable,
       jsonName: jsonName,
+      isExternal: isExternal,
     );
   }
 
@@ -183,12 +207,14 @@ class FieldDefinition {
     String? type,
     bool? nullable,
     String? jsonName,
+    bool? isExternal,
   }) {
     return FieldDefinition(
       name: name ?? this.name,
       type: type ?? this.type,
       nullable: nullable ?? this.nullable,
       jsonName: jsonName ?? this.jsonName,
+      isExternal: isExternal ?? this.isExternal,
     );
   }
 }

--- a/zorphy/lib/src/cli/services/field_normalizer.dart
+++ b/zorphy/lib/src/cli/services/field_normalizer.dart
@@ -11,6 +11,12 @@ class FieldNormalizer {
 
   /// Normalize a field type by adding $ prefix for entity types
   String normalize(String type) {
+    // External types (`!Type` marker) are kept as-is with no `$` prefix —
+    // they live outside the entity tree and are imported by the user.
+    if (type.startsWith('!')) {
+      return type.substring(1);
+    }
+
     final isNullable = type.endsWith('?');
     final cleanType = isNullable ? type.substring(0, type.length - 1) : type;
 
@@ -46,6 +52,12 @@ class FieldNormalizer {
 
   /// Normalize a FieldDefinition
   FieldDefinition normalizeField(FieldDefinition field) {
+    // External types (`!Type` marker) are never entity/enum: the type was
+    // already stripped of the `!` by [FieldDefinition.parse] and must NOT
+    // receive a `$` prefix or nullable-stripping.
+    if (field.isExternal) {
+      return field;
+    }
     final normalizedType = normalize(field.type);
     return field.copyWith(type: normalizedType.replaceAll('?', ''));
   }

--- a/zorphy/lib/src/cli/services/import_resolver.dart
+++ b/zorphy/lib/src/cli/services/import_resolver.dart
@@ -22,6 +22,9 @@ class ImportResolver {
     bool needsEnumImport = false;
 
     for (final field in fields) {
+      // External types (`!Type` marker) are imported by the user — no
+      // entity/enum import can or should be resolved for them.
+      if (field.isExternal) continue;
       final typeRefs = NamingUtils.extractTypeReferences(field.type);
 
       for (final typeRef in typeRefs) {
@@ -81,6 +84,9 @@ class ImportResolver {
     bool needsEnumImport = false;
 
     for (final field in fields) {
+      // External types (`!Type` marker) are imported by the user — no
+      // entity/enum import can or should be resolved for them.
+      if (field.isExternal) continue;
       final typeRefs = NamingUtils.extractTypeReferences(field.type);
 
       for (final typeRef in typeRefs) {

--- a/zorphy/test/cli/services/external_type_field_test.dart
+++ b/zorphy/test/cli/services/external_type_field_test.dart
@@ -1,0 +1,147 @@
+// Regression tests for the `!Type` external-type field marker (issue #349).
+//
+// The `!` prefix (e.g. `url:!WebUri?`) marks a field type as EXTERNAL — a
+// type living outside the entity tree (plugin wrappers like `WebUri`, SDK
+// classes, ...). External types must be:
+//   1. kept as-is by `FieldDefinition.parse` (no `$` prefix, `!` stripped),
+//   2. NOT `$`-prefixed by `FieldNormalizer`,
+//   3. NOT resolved to entity/enum imports by `ImportResolver`,
+//   4. skipped by on-disk validation (zuraffa side).
+//
+// Before the fix, `--field request:!URLRequest` produced `$!URLRequest get
+// request;` in the generated source (the `!` was treated as part of the
+// type name by `_determinePrefix`), which the builder then misparsed into a
+// phantom `$` field (`required dynamic $`) and the build failed.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:zorphy/zorphy.dart';
+
+void main() {
+  group('FieldDefinition.parse external marker (!)', () {
+    test('parses !Type', () {
+      final f = FieldDefinition.parse('url:!WebUri');
+      expect(f.name, 'url');
+      expect(f.type, 'WebUri');
+      expect(f.nullable, isFalse);
+      expect(f.isExternal, isTrue);
+      expect(f.fullType, 'WebUri');
+    });
+
+    test('parses !Type?', () {
+      final f = FieldDefinition.parse('url:!WebUri?');
+      expect(f.name, 'url');
+      expect(f.type, 'WebUri');
+      expect(f.nullable, isTrue);
+      expect(f.isExternal, isTrue);
+      expect(f.fullType, 'WebUri?');
+    });
+
+    test('plain type is not external', () {
+      final f = FieldDefinition.parse('id:String');
+      expect(f.isExternal, isFalse);
+    });
+
+    test('rejects bare !', () {
+      expect(() => FieldDefinition.parse('url:!'), throwsArgumentError);
+    });
+  });
+
+  group('EntityCreator end-to-end external marker (!)', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('zorphy_349_');
+    });
+
+    tearDown(() async {
+      await tmp.delete(recursive: true);
+    });
+
+    Future<String> createEntityWithExternalField(
+      String refType,
+    ) async {
+      final creator = EntityCreator(baseOutputDir: tmp.path);
+      final field = FieldDefinition.parse('url:$refType');
+      final result = await creator.create(
+        EntityConfig(
+          name: 'ExternalHolder',
+          outputDir: tmp.path,
+          fields: [field],
+        ),
+      );
+      expect(result.isSuccess, isTrue, reason: result.error);
+      return File(result.filePath).readAsString();
+    }
+
+    test('external field emits plain type, no \$ prefix, no bogus import',
+        () async {
+      final src = await createEntityWithExternalField('!WebUri?');
+
+      // The field declaration must be the PLAIN type (no `\$` prefix, no
+      // `!` leak).
+      expect(
+        src,
+        contains('WebUri? get url;'),
+        reason: 'External type must be emitted verbatim without the `\$` '
+            'prefix or the `!` marker.',
+      );
+      expect(
+        src,
+        isNot(contains(r'$!WebUri')),
+        reason: '`\$!WebUri` is the #349 defect — `!` was treated as part '
+            'of the type name and `\$`-prefixed by `_determinePrefix`.',
+      );
+      expect(
+        src,
+        isNot(contains(r'$WebUri')),
+        reason: 'External types are not entities — no `\$` prefix.',
+      );
+      // No entity import for the external type, and no bogus enum import.
+      expect(
+        src,
+        isNot(contains("import '../web_uri/web_uri.dart';")),
+        reason: 'No entity import must be resolved for an external type.',
+      );
+      expect(
+        src,
+        isNot(contains("import '../enums/index.dart';")),
+        reason: 'No enum import must be resolved for an external type.',
+      );
+    });
+
+    test('external non-nullable field emits plain type', () async {
+      final src = await createEntityWithExternalField('!WebUri');
+      expect(src, contains('WebUri get url;'));
+      expect(src, isNot(contains(r'$WebUri')));
+    });
+
+    test('external field next to entity field keeps sibling prefixing',
+        () async {
+      final creator = EntityCreator(baseOutputDir: tmp.path);
+      final result = await creator.create(
+        EntityConfig(
+          name: 'MixedHolder',
+          outputDir: tmp.path,
+          fields: [
+            FieldDefinition.parse('url:!WebUri?'),
+            FieldDefinition.parse('peer:SiblingEntity?'),
+          ],
+        ),
+      );
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final src = await File(result.filePath).readAsString();
+      // External stays plain; forward-referenced sibling entity keeps the
+      // `$` prefix (existing behavior must not regress).
+      expect(src, contains('WebUri? get url;'));
+      expect(src, contains(r'$SiblingEntity? get peer;'));
+      // The sibling import is still resolved.
+      expect(
+        src,
+        contains("import '../sibling_entity/sibling_entity.dart';"),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Issue #349: the documented external-type field syntax `!Type` (e.g. `--field url:!WebUri?`) is broken end-to-end. The `!` marker leaks into the generated source:

```
--field request:!URLRequest   →   '$!URLRequest get request;'
```

`FieldNormalizer._determinePrefix` treats `!URLRequest` as a type name, finds no on-disk entity directory, and applies the `$` forward-reference prefix. The builder then misparses `$!URLRequest` and emits a phantom `$` field (`required dynamic $`, `Field<..., dynamic>('$', ...)`), and the build fails.

Additionally, `ImportResolver` treats the external type as an unknown enum and emits a bogus `import '../enums/index.dart';`.

Note: zuraffa #349 fix `def7d5f` (branch `fix/349-external-type-no-dollar-prefix`) already skips external fields in its post-processing, but it relies on `FieldDefinition.isExternal` from zorphy — which never landed here (the referenced zorphy `05feef3` does not exist in this repo's history). This PR provides that missing half.

## Fix

- `FieldDefinition.parse`: strips a leading `!` from the type and sets `isExternal = true` (rejects bare `!`)
- `FieldNormalizer.normalizeField`: external fields bypass prefixing entirely — plain type, no `$`, nullable flag preserved
- `FieldNormalizer.normalize`: defensively strips a stray `!` from raw type strings
- `ImportResolver` (both `resolveImports` and `resolveSubtypeImports`): skips external fields — no entity import, no bogus enum import

External types are imported by the user in the generated entity source (documented workflow).

## Branch contents

This branch is based on `development` and also carries the #310 comment-safety hardening (`2d093f1`) and the #351 cross-entity concrete-reference recovery (`c09d966`) — the three fixes zuraffa's zorphy git ref currently needs, so zuraffa can point at ONE ref (`fix/349-external-type-no-dollar-prefix-cli`).

## Verification

- New regression suite `test/cli/services/external_type_field_test.dart` (7 tests): parse variants, end-to-end `EntityCreator.create()` with external fields (nullable/non-nullable), mixed external + forward-ref sibling entity fields
- Full `dart test`: 164 passing; the only failure is pre-existing `test/generation/issue_304_extends_test.dart` (fixture not generated on this base — needs `cd example && dart run build_runner build`, unrelated to this change)
- `dart analyze lib/src/cli`: No issues found
- Cross-checked from zuraffa: #349 (5/5) and #351 (1/1) regression tests pass against this branch; scratch `zfa entity create --field url:!WebUri?` emits `WebUri? get url;`, no bogus imports, build_runner resolves the external type