### PR TITLE
fix(migrator): sanitize '///- ' doc lines (#88) + enum wire notes informational (regression from the #87 squash)

### DIFF
--- a/zorphy_migrator/lib/src/cli.dart
+++ b/zorphy_migrator/lib/src/cli.dart
@@ -100,6 +100,10 @@ class MigratorCli {
 
       final replacements = replacementsFor(fileModels, renderer.render);
       for (final m in fileModels) {
+        // Informational items ride along on converted models too (e.g. an
+        // enum wire that needs consumer glue) — the conversion is safe, the
+        // report still tells the reader what to check by hand.
+        manual.addAll(m.informationalItems);
         if (m.isMigratable) {
           final notes = <String>[];
           if (m.dialect == ModelDialect.freezed &&

--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -270,6 +270,11 @@ class ExchangeableDetector {
     final enumMemberDocs = <String?>[];
     final intValues = <int>[];
 
+    // Wire mismatches do NOT block the enum conversion (names/order are
+    // preserved; only the consumer glue needs hand attention), so they are
+    // reported as informational items on the converted model.
+    final informational = <ManualItem>[];
+
     for (final member in members) {
       if (member is! FieldDeclaration) continue;
       for (final variable in member.fields.variables) {
@@ -295,7 +300,7 @@ class ExchangeableDetector {
           // String wire value — keep the member name; a differing wire
           // string needs hand glue in the entity's @JsonKey.
           if (arg != "'$memberName'" && arg != '"$memberName"') {
-            manual.add(
+            informational.add(
               ManualItem(
                 filePath: unit.path,
                 line: lineInfo.getLocation(variable.offset).lineNumber,
@@ -314,7 +319,7 @@ class ExchangeableDetector {
     // exactly 0..n-1 in declaration order.
     if (intValues.isNotEmpty &&
         !_isSequential(intValues)) {
-      manual.add(
+      informational.add(
         ManualItem(
           filePath: unit.path,
           line: lineInfo.getLocation(node.offset).lineNumber,
@@ -337,6 +342,7 @@ class ExchangeableDetector {
       hasToJson: false,
       isUnfreezed: false,
       manualItems: manual,
+      informationalItems: informational,
       spanStart: node.offset,
       spanEnd: node.end,
       docComment: doc,

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -106,7 +106,7 @@ class ZorphyRenderer {
   void _renderSimple(FreezedClassModel model, StringBuffer sb) {
     final className = '\$${model.name}';
 
-    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment!));
     sb.writeln(_annotationFor(model));
     sb.writeln('abstract class $className${_typeParams(model)} {');
     for (final field in model.fields) {
@@ -150,7 +150,7 @@ class ZorphyRenderer {
       doc.replaceAll('///- ', '///').replaceAll('/// ', '///');
 
   void _renderExchangeableObject(FreezedClassModel model, StringBuffer sb) {
-    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment!));
     sb
       ..writeln('@Zorphy(')
       ..writeln('  kind: ZorphyKind.valueObject,')
@@ -185,7 +185,7 @@ class ZorphyRenderer {
   /// enum. Member names and declaration order (== the old wire order) are
   /// preserved; doc comments are kept on the members.
   void _renderExchangeableEnum(FreezedClassModel model, StringBuffer sb) {
-    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment!));
     sb.writeln('enum ${model.name} {');
     for (var i = 0; i < model.enumMembers.length; i++) {
       final doc = model.enumMemberDocs.length > i
@@ -206,7 +206,7 @@ class ZorphyRenderer {
     // abstract classes (zorphy convention, see README "Sealed Abstract
     // Classes").
     final baseJson = model.hasFromJson || model.hasToJson;
-    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment!));
     sb.writeln(
       _annotationFor(
         model,

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -106,7 +106,7 @@ class ZorphyRenderer {
   void _renderSimple(FreezedClassModel model, StringBuffer sb) {
     final className = '\$${model.name}';
 
-    if (model.docComment != null) sb.writeln(model.docComment);
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
     sb.writeln(_annotationFor(model));
     sb.writeln('abstract class $className${_typeParams(model)} {');
     for (final field in model.fields) {
@@ -141,8 +141,16 @@ class ZorphyRenderer {
   /// Renders an `@ExchangeableObject()` value object as a Zorphy value
   /// entity, matching the zikzak_inappwebview conversion convention
   /// (see PROGRESS.md recipe).
+  /// The zorphy generator (issue #88) leaks the content of doc-comment
+  /// lines written as `///- X` (or `/// X`) into the generated constructor —
+  /// the `- ` / space after `///` is consumed and the remaining token is
+  /// emitted as code, breaking the build. Normalize such lines to the
+  /// working `///X` form (content preserved, no space after the markers).
+  String _sanitizeDoc(String doc) =>
+      doc.replaceAll('///- ', '///').replaceAll('/// ', '///');
+
   void _renderExchangeableObject(FreezedClassModel model, StringBuffer sb) {
-    if (model.docComment != null) sb.writeln(model.docComment);
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
     sb
       ..writeln('@Zorphy(')
       ..writeln('  kind: ZorphyKind.valueObject,')
@@ -159,7 +167,7 @@ class ZorphyRenderer {
   void _renderExchangeableField(FreezedField field, StringBuffer sb) {
     final fieldDoc = field.docComment;
     if (fieldDoc != null) {
-      for (final line in fieldDoc.split('\n')) {
+      for (final line in _sanitizeDoc(fieldDoc).split('\n')) {
         sb.writeln('  $line');
       }
     }
@@ -177,7 +185,7 @@ class ZorphyRenderer {
   /// enum. Member names and declaration order (== the old wire order) are
   /// preserved; doc comments are kept on the members.
   void _renderExchangeableEnum(FreezedClassModel model, StringBuffer sb) {
-    if (model.docComment != null) sb.writeln(model.docComment);
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
     sb.writeln('enum ${model.name} {');
     for (var i = 0; i < model.enumMembers.length; i++) {
       final doc = model.enumMemberDocs.length > i
@@ -198,7 +206,7 @@ class ZorphyRenderer {
     // abstract classes (zorphy convention, see README "Sealed Abstract
     // Classes").
     final baseJson = model.hasFromJson || model.hasToJson;
-    if (model.docComment != null) sb.writeln(model.docComment);
+    if (model.docComment != null) sb.writeln(_sanitizeDoc(model.docComment));
     sb.writeln(
       _annotationFor(
         model,

--- a/zorphy_migrator/lib/src/model.dart
+++ b/zorphy_migrator/lib/src/model.dart
@@ -101,6 +101,13 @@ class FreezedClassModel {
   /// (aligned with [enumMembers]), or `null` where the member had none.
   final List<String?> enumMemberDocs;
 
+  /// Non-blocking items reported alongside a converted model: the model
+  /// still migrates, but the reader is told what needs hand attention
+  /// afterwards (e.g. an enum whose wire values do not map onto a plain
+  /// enum's `.index`/name — the conversion is safe, the consumer glue is
+  /// not). Unlike [manualItems], these do NOT make the model unmigratable.
+  final List<ManualItem> informationalItems;
+
   /// Character offsets of the full class declaration in the source.
   final int spanStart;
   final int spanEnd;
@@ -125,6 +132,7 @@ class FreezedClassModel {
     this.dialect = ModelDialect.freezed,
     this.enumMembers = const [],
     this.enumMemberDocs = const [],
+    this.informationalItems = const [],
   });
 
   bool get isUnion => variants.isNotEmpty;

--- a/zorphy_migrator/test/fixtures/exchangeable_enum/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_enum/expected.dart
@@ -9,3 +9,9 @@ enum JsAlertResponseAction {
   ///Confirm that the user hit confirm button.
   CONFIRM,
 }
+
+enum URLRequestNetworkServiceType {
+  DEFAULT,
+  VIDEO,
+  BACKGROUND,
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_enum/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_enum/input.dart
@@ -24,3 +24,14 @@ class JsAlertResponseAction_ {
   ///Confirm that the user hit confirm button.
   static const CONFIRM = const JsAlertResponseAction_._internal(0);
 }
+
+@ExchangeableEnum()
+class URLRequestNetworkServiceType_ {
+  // ignore: unused_field
+  final int _value;
+  const URLRequestNetworkServiceType_._internal(this._value);
+
+  static const DEFAULT = const URLRequestNetworkServiceType_._internal(0);
+  static const VIDEO = const URLRequestNetworkServiceType_._internal(2);
+  static const BACKGROUND = const URLRequestNetworkServiceType_._internal(3);
+}

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -167,6 +167,19 @@ void main() {
       );
       expect(navigation.manualItems, isEmpty);
       expect(navigation.isMigratable, isTrue);
+
+      // Non-sequential int wire values do NOT block the conversion — the
+      // enum still migrates, but an informational item flags the wire glue.
+      final networkServiceType = models.singleWhere(
+        (m) => m.name == 'URLRequestNetworkServiceType',
+      );
+      expect(networkServiceType.enumMembers, ['DEFAULT', 'VIDEO', 'BACKGROUND']);
+      expect(networkServiceType.isMigratable, isTrue);
+      expect(networkServiceType.informationalItems, isNotEmpty);
+      expect(
+        networkServiceType.informationalItems.single.reason,
+        contains('not sequential 0..n-1'),
+      );
     });
   });
 


### PR DESCRIPTION
Re-applies three commits that were dropped when PR #87 was squashed:

1. **fix(migrator): sanitize '///- ' doc-comment list lines** — the zorphy generator (#88) leaks the content of `///- X` doc lines into the generated constructor; normalize to the working `///X` form in the exchangeable renderers.
2. **fix(migrator): convert enums with non-sequential wire values** — wire mismatches are informational (the enum conversion is safe; only the consumer glue is manual), not blocking.
3. null-assert docComment in the sanitizer call sites.

Without these, non-sequential int-wire enums (e.g. PrintJobColorMode 1,2 / PrintJobState 1..7) block the migration and any settings family with `///- ` platform-list docs fails to build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration reports now include informational notices for non-blocking issues, including non-sequential enum values.
  * Models with informational notices can still be migrated successfully.
  * Documentation comments are normalized for consistent generated output.

* **Bug Fixes**
  * Exchangeable enum wire-value mismatches no longer incorrectly block migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->