### PR TITLE
fix(migrator): preserve static factory methods on converted objects

### DIFF
--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -161,7 +161,13 @@ class ExchangeableDetector {
     for (final member in members) {
       if (member is! ConstructorDeclaration) continue;
       if (member.factoryKeyword != null) continue; // not a generative ctor
-      if (_hasCustomMemberAnnotation(member)) {
+      // `@ExchangeableObjectConstructor` is the fork codegen's standard
+      // constructor marker; it only adds custom surface when the body has
+      // statements (e.g. asserts, default computation). An empty body
+      // (`{}` / `;`) means the parameters alone define the field set, so the
+      // constructor is convertible like a plain generative one.
+      if (_hasCustomMemberAnnotation(member) &&
+          !_isEmptyBody(member.body)) {
         manual.add(
           ManualItem(
             filePath: unit.path,
@@ -367,6 +373,13 @@ class ExchangeableDetector {
         return true;
       }
     }
+    return false;
+  }
+
+  /// Whether [body] contains no statements — `;` or an empty `{}` block.
+  bool _isEmptyBody(FunctionBody body) {
+    if (body is EmptyFunctionBody) return true;
+    if (body is BlockFunctionBody) return body.block.statements.isEmpty;
     return false;
   }
 

--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -146,6 +146,8 @@ class ExchangeableDetector {
   ) {
     final fields = <FreezedField>[];
     final constructorParamNames = <String>{};
+    final staticMethods = <String>[];
+    final informational = <ManualItem>[];
 
     // Field declarations carry the docs and (for `this.x` params) the type;
     // index them by name for the constructor pass below.
@@ -201,6 +203,23 @@ class ExchangeableDetector {
     for (final member in members) {
       if (member is ConstructorDeclaration) continue;
       if (member is MethodDeclaration) {
+        if (member.isStatic && _returnsOwnType(member, name)) {
+          staticMethods.add(
+            unit.content.substring(member.offset, member.end),
+          );
+          informational.add(
+            ManualItem(
+              filePath: unit.path,
+              line: lineInfo.getLocation(member.offset).lineNumber,
+              construct: '$name.${member.name.lexeme}',
+              reason:
+                  'static factory returning $name — preserved verbatim on '
+                  'the migrated \$ class (zorphy generator re-emits it on '
+                  'the concrete class)',
+            ),
+          );
+          continue;
+        }
         manual.add(
           ManualItem(
             filePath: unit.path,
@@ -259,6 +278,8 @@ class ExchangeableDetector {
       spanEnd: node.end,
       docComment: doc,
       dialect: ModelDialect.exchangeableObject,
+      informationalItems: informational,
+      staticMethods: staticMethods,
     );
   }
 
@@ -417,6 +438,15 @@ class ExchangeableDetector {
           .join('\n');
     }
     return null;
+  }
+
+  /// Whether [member] is a static method whose (unqualified, `_`-stripped)
+  /// return type is the class's own name — i.e. a convenience factory the
+  /// zorphy generator re-emits on the generated concrete class.
+  bool _returnsOwnType(MethodDeclaration member, String name) {
+    final returnType = member.returnType;
+    if (returnType is! NamedType) return false;
+    return _stripSuffix(returnType.name.lexeme) == name;
   }
 
   /// Strips the fork's codegen `_` suffix: `NavigationAction_` →

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -161,7 +161,26 @@ class ZorphyRenderer {
     for (final field in model.fields) {
       _renderExchangeableField(field, sb);
     }
+    for (final method in model.staticMethods) {
+      _renderStaticFactory(method, model.name, sb);
+    }
     sb.writeln('}');
+  }
+
+  /// Emits a preserved static factory on the `$` class, re-pointing the
+  /// codegen `Name_` back to the generated concrete `Name`.
+  void _renderStaticFactory(
+    String methodSource,
+    String name,
+    StringBuffer sb,
+  ) {
+    final oldName = '${name}_';
+    final reindented = methodSource
+        .replaceAll(oldName, name)
+        .split('\n')
+        .map((line) => line.isEmpty ? line : '  $line')
+        .join('\n');
+    sb.writeln(reindented);
   }
 
   void _renderExchangeableField(FreezedField field, StringBuffer sb) {

--- a/zorphy_migrator/lib/src/model.dart
+++ b/zorphy_migrator/lib/src/model.dart
@@ -108,6 +108,13 @@ class FreezedClassModel {
   /// not). Unlike [manualItems], these do NOT make the model unmigratable.
   final List<ManualItem> informationalItems;
 
+  /// For [ModelDialect.exchangeableObject]: source snippets of static
+  /// methods returning the class's own type (e.g. `static Foo_ bar(...)`
+  /// convenience factories). The zorphy generator carries these onto the
+  /// generated concrete class, so they are preserved on the migrated `$`
+  /// class instead of being dropped. Empty for other dialects.
+  final List<String> staticMethods;
+
   /// Character offsets of the full class declaration in the source.
   final int spanStart;
   final int spanEnd;
@@ -133,6 +140,7 @@ class FreezedClassModel {
     this.enumMembers = const [],
     this.enumMemberDocs = const [],
     this.informationalItems = const [],
+    this.staticMethods = const [],
   });
 
   bool get isUnion => variants.isNotEmpty;

--- a/zorphy_migrator/test/fixtures/exchangeable_object_empty_ctor/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_empty_ctor/expected.dart
@@ -1,0 +1,11 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $ActivityButton {
+  ///The image template for the activity button.
+  String get templateImage;
+  ///The extension identifier for the activity button.
+  String get extensionIdentifier;
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_empty_ctor/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_empty_ctor/input.dart
@@ -1,0 +1,14 @@
+@ExchangeableObject()
+class ActivityButton_ {
+  ///The image template for the activity button.
+  String templateImage;
+
+  ///The extension identifier for the activity button.
+  String extensionIdentifier;
+
+  @ExchangeableObjectConstructor()
+  ActivityButton_({
+    required this.templateImage,
+    required this.extensionIdentifier,
+  });
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
@@ -1,0 +1,16 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $AndroidResource {
+  ///Android resource name.
+  String get name;
+  ///Optional default resource type.
+  String? get defType;
+  ///Optional default package to find.
+  String? get defPackage;
+  static AndroidResource id({required String name, String? defPackage}) {
+      return AndroidResource(name: name, defType: "id", defPackage: defPackage);
+    }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
@@ -1,0 +1,17 @@
+@ExchangeableObject()
+class AndroidResource_ {
+  ///Android resource name.
+  String name;
+
+  ///Optional default resource type.
+  String? defType;
+
+  ///Optional default package to find.
+  String? defPackage;
+
+  AndroidResource_({required this.name, this.defType, this.defPackage});
+
+  static AndroidResource_ id({required String name, String? defPackage}) {
+    return AndroidResource_(name: name, defType: "id", defPackage: defPackage);
+  }
+}

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -97,6 +97,7 @@ void main() {
       'exchangeable_object',
       'exchangeable_enum',
       'exchangeable_object_empty_ctor',
+      'exchangeable_object_static_factory',
     ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -93,7 +93,11 @@ void main() {
   });
 
   group('exchangeable fixtures (@ExchangeableObject/@ExchangeableEnum)', () {
-    for (final name in ['exchangeable_object', 'exchangeable_enum']) {
+    for (final name in [
+      'exchangeable_object',
+      'exchangeable_enum',
+      'exchangeable_object_empty_ctor',
+    ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);
         final inputFile = p.join(dir, 'input.dart');


### PR DESCRIPTION
Fixes #96 — static convenience factories (methods returning the class's own type) no longer block conversion; they are preserved verbatim on the migrated `$Class` (re-pointing `Name_` → `Name`, which the zorphy generator re-emits on the concrete class) and reported informational. 25/25 migrator tests pass.