### PR TITLE
fix(ci): unbreak GitHub Actions after v2.0.0 merge

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -6,6 +6,12 @@ on:
       - "v*"
   workflow_dispatch:
 
+# The release upload (softprops/action-gh-release) creates/updates a GitHub
+# Release and uploads binary assets — requires a write token. The repo
+# default is read-only, so the release job fails with 403 without this.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.platform }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -91,16 +91,20 @@ jobs:
           # analyzer <14.0.0; it is a dev-only dependency, so the override
           # below unblocks CI without touching the published constraint.
           # Remove once a json_serializable release supports analyzer 14.
+          # pubspec_overrides.yaml only supports `dependency_overrides`,
+          # `resolution` and `workspace` keys — the pin must be nested under
+          # `dependency_overrides:`, not written at the top level.
           if [ "${{ matrix.analyzer }}" = "14" ]; then
-            cat >> pubspec_overrides.yaml <<'EOF'
-            analyzer: ^14.0.0
-            json_serializable:
-              git:
-                url: https://github.com/google/json_serializable.dart
-                path: json_serializable
-          EOF
+            cat > pubspec_overrides.yaml <<'EOF'
+dependency_overrides:
+  analyzer: ^14.0.0
+  json_serializable:
+    git:
+      url: https://github.com/google/json_serializable.dart
+      path: json_serializable
+EOF
           else
-            printf '  analyzer: ^13.0.0\n' >> pubspec_overrides.yaml
+            printf 'dependency_overrides:\n  analyzer: ^13.0.0\n' > pubspec_overrides.yaml
           fi
           cat pubspec_overrides.yaml
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -95,14 +95,7 @@ jobs:
           # `resolution` and `workspace` keys — the pin must be nested under
           # `dependency_overrides:`, not written at the top level.
           if [ "${{ matrix.analyzer }}" = "14" ]; then
-            cat > pubspec_overrides.yaml <<'EOF'
-dependency_overrides:
-  analyzer: ^14.0.0
-  json_serializable:
-    git:
-      url: https://github.com/google/json_serializable.dart
-      path: json_serializable
-EOF
+            printf 'dependency_overrides:\n  analyzer: ^14.0.0\n  json_serializable:\n    git:\n      url: https://github.com/google/json_serializable.dart\n      path: json_serializable\n' > pubspec_overrides.yaml
           else
             printf 'dependency_overrides:\n  analyzer: ^13.0.0\n' > pubspec_overrides.yaml
           fi

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -45,6 +45,11 @@ jobs:
 
   deploy:
     needs: build
+    # GitHub Pages deployments are only valid from the production branch
+    # (master). PR runs and other-branch pushes build the site as CI but
+    # must not attempt a Pages deployment — actions/deploy-pages rejects
+    # non-production refs and reds the job.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/zorphy/test/cli/services/external_type_field_test.dart
+++ b/zorphy/test/cli/services/external_type_field_test.dart
@@ -15,7 +15,6 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:zorphy/zorphy.dart';
 

--- a/zorphy/test/plugin_ordering_test.dart
+++ b/zorphy/test/plugin_ordering_test.dart
@@ -1,5 +1,4 @@
 import 'package:test/test.dart';
-import 'package:zorphy/src/plugins/plugin_registry.dart';
 import 'package:zorphy/zorphy_plugin.dart';
 
 /// A plugin with no ordering constraints.

--- a/zorphy/test/plugin_pipeline_test.dart
+++ b/zorphy/test/plugin_pipeline_test.dart
@@ -7,8 +7,6 @@ import 'package:zorphy/src/factory_method.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 import 'package:zorphy/src/models/interface_metadata.dart';
-import 'package:zorphy/src/plugins/plugin_context.dart';
-import 'package:zorphy/src/plugins/plugin_registry.dart';
 import 'package:zorphy/zorphy_plugin.dart';
 
 /// A test double plugin that adds a `_telemetry` field.

--- a/zorphy_migrator/test/fixtures/exchangeable_object_ctor_initializers/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_ctor_initializers/input.dart
@@ -1,0 +1,10 @@
+@ExchangeableObject()
+class BadgeView_ {
+  ///The badge text.
+  String text;
+
+  @ExchangeableObjectConstructor()
+  BadgeView_({
+    required this.text,
+  }) : assert(text.length < 100);
+}


### PR DESCRIPTION
## What

Five distinct CI fixes, each verified locally:

1. **analyze_and_test** — removed the unused `package:path/path.dart` import in `external_type_field_test.dart` (the 1 warning that kept `dart analyze` red on master).
2. **analyzer_compat (13/14)** — `pubspec_overrides.yaml` only supports `dependency_overrides`/`resolution`/`workspace` keys; the pin heredoc wrote top-level `analyzer:` entries, failing `dart pub get` on both legs. Now nested under `dependency_overrides:`.
3. **migrator** — `migration_test.dart` references the `exchangeable_object_ctor_initializers` fixture, which was never committed → `PathNotFoundException`. Added the fixture (ctor initializer → report-only, manual item recorded).
4. **deploy-website** — `actions/deploy-pages` ran on PRs and non-master pushes and failed; gated `deploy` to master pushes (build still runs everywhere as CI).
5. **build-binaries** — repo default workflow token is read-only; the release upload needs `contents: write` (v2.0.0 tag run failed at "Upload to Release").

Also removes 3 `unnecessary_import` infos in the plugin tests (symbols are re-exported by `zorphy_plugin.dart`).

## Verification (local)

- `cd zorphy && dart analyze` → No issues found (after regenerating `test_cli_output` + `example`)
- `cd zorphy && dart test` → 181/181 pass
- `cd zorphy_migrator && dart test` → 25/25 pass
- analyzer_compat legs: resolves analyzer 13.3.0 / 14.1.0, `dart analyze lib` clean on both

## Fixes CI on master

- Dart CI: analyze_and_test, analyzer_compat (13 + 14), migrator
- Deploy Docusaurus: PR/other-branch runs
- Build Binaries: tag release upload (next tag)