### PR TITLE
fix(migrator): drop assert-only constructor bodies instead of blocking (closes #99)

### DIFF
--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -146,6 +146,7 @@ class ExchangeableDetector {
   ) {
     final fields = <FreezedField>[];
     final constructorParamNames = <String>{};
+    final informational = <ManualItem>[];
 
     // Field declarations carry the docs and (for `this.x` params) the type;
     // index them by name for the constructor pass below.
@@ -167,7 +168,8 @@ class ExchangeableDetector {
       // (`{}` / `;`) means the parameters alone define the field set, so the
       // constructor is convertible like a plain generative one.
       if (_hasCustomMemberAnnotation(member) &&
-          !_isEmptyBody(member.body)) {
+          !_isEmptyBody(member.body) &&
+          !_isAssertOnlyBody(member.body)) {
         manual.add(
           ManualItem(
             filePath: unit.path,
@@ -177,6 +179,18 @@ class ExchangeableDetector {
           ),
         );
         continue;
+      }
+      if (_isAssertOnlyBody(member.body)) {
+        informational.add(
+          ManualItem(
+            filePath: unit.path,
+            line: lineInfo.getLocation(member.offset).lineNumber,
+            construct: name,
+            reason:
+                'assert-only constructor body dropped — dev-time invariant '
+                'checks cannot be expressed on the Zorphy entity',
+          ),
+        );
       }
       for (final param in member.parameters.parameters) {
         final paramName = param.name?.lexeme;
@@ -259,6 +273,7 @@ class ExchangeableDetector {
       spanEnd: node.end,
       docComment: doc,
       dialect: ModelDialect.exchangeableObject,
+      informationalItems: informational,
     );
   }
 
@@ -381,6 +396,17 @@ class ExchangeableDetector {
     if (body is EmptyFunctionBody) return true;
     if (body is BlockFunctionBody) return body.block.statements.isEmpty;
     return false;
+  }
+
+  /// Whether [body] contains only `assert(...)` statements — dev-time
+  /// invariant checks the zorphy generator cannot express. Such bodies add
+  /// no serialization surface, so they are dropped (informational) instead
+  /// of blocking the conversion.
+  bool _isAssertOnlyBody(FunctionBody body) {
+    if (body is! BlockFunctionBody) return false;
+    final statements = body.block.statements;
+    if (statements.isEmpty) return false;
+    return statements.every((s) => s is AssertStatement);
   }
 
   /// The declared type of a constructor parameter. For `this.x` params the

--- a/zorphy_migrator/test/fixtures/exchangeable_object_assert_body/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_assert_body/expected.dart
@@ -1,0 +1,9 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $UIImage {
+  ///The name of the image asset.
+  String? get name;
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_assert_body/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_assert_body/input.dart
@@ -1,0 +1,10 @@
+@ExchangeableObject()
+class UIImage_ {
+  ///The name of the image asset.
+  String? name;
+
+  @ExchangeableObjectConstructor()
+  UIImage_({this.name}) {
+    assert(this.name != null);
+  }
+}

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -188,6 +188,160 @@ void main() {
     });
   });
 
+  group('assert-only constructor body handling (#99)', () {
+    /// Stages inline source as a minimal package and returns the absolute
+    /// path of the staged input. Unresolved `@ExchangeableObject`
+    /// annotations are tolerated — the detector matches by simple name,
+    /// like the existing exchangeable fixtures.
+    String stageInline(Directory scratch, String content) {
+      final inputFile = File(p.join(scratch.path, 'input.dart'))
+        ..writeAsStringSync(content);
+      File(p.join(scratch.path, 'pubspec.yaml')).writeAsStringSync(
+        'name: scratch_assert_99\n'
+        'environment:\n'
+        '  sdk: ">=3.8.0 <4.0.0"\n'
+        'dependencies:\n'
+        '  freezed_annotation: ^3.1.0\n',
+      );
+      final result = Process.runSync('dart', ['pub', 'get'],
+          workingDirectory: scratch.path);
+      if (result.exitCode != 0) {
+        fail('pub get failed in scratch package: ${result.stderr}');
+      }
+      return inputFile.absolute.path;
+    }
+
+    test(
+        'assert-only bodies convert with a note; non-assert and mixed stay manual',
+        () async {
+      final scratch =
+          Directory.systemTemp.createTempSync('zorphy_assert_99');
+      try {
+        final path = stageInline(scratch, r'''
+@ExchangeableObject()
+class MultiAssert_ {
+  ///The left edge.
+  double? left;
+
+  ///The top edge.
+  double? top;
+
+  ///The width.
+  double? width;
+
+  ///The height.
+  double? height;
+
+  @ExchangeableObjectConstructor()
+  MultiAssert_({this.left, this.top, this.width, this.height}) {
+    assert(left == null || left >= 0);
+    assert(top == null || top >= 0);
+    assert(width == null || width >= 0);
+    assert(height == null || height >= 0);
+  }
+}
+
+@ExchangeableObject()
+class DefaultComputation_ {
+  ///The script source.
+  String? source;
+
+  ///The allowed origin rules (defaulted in the body).
+  List<String>? allowedOriginRules;
+
+  @ExchangeableObjectConstructor()
+  DefaultComputation_({this.source, this.allowedOriginRules}) {
+    this.allowedOriginRules = this.allowedOriginRules ?? const <String>['*'];
+  }
+}
+
+@ExchangeableObject()
+class MixedBody_ {
+  ///A value.
+  String? value;
+
+  ///A normalized value.
+  String? normalized;
+
+  @ExchangeableObjectConstructor()
+  MixedBody_({this.value, this.normalized}) {
+    assert(value != null || normalized != null);
+    this.normalized = this.normalized ?? this.value;
+  }
+}
+
+@ExchangeableObject()
+class EmptyBody_ {
+  ///The template image.
+  String templateImage;
+
+  ///The extension identifier.
+  String extensionIdentifier;
+
+  @ExchangeableObjectConstructor()
+  EmptyBody_({required this.templateImage, required this.extensionIdentifier});
+}
+''');
+        final models = await ExchangeableDetector().detect([path]);
+
+        // (1) Assert-only body (multiple asserts) -> converts, and an
+        //     informational note records the dropped asserts. Fields are
+        //     collected from the constructor parameters.
+        final multiAssert =
+            models.singleWhere((m) => m.name == 'MultiAssert');
+        expect(multiAssert.isMigratable, isTrue,
+            reason: 'an assert-only body must not block conversion');
+        expect(multiAssert.manualItems, isEmpty);
+        expect(multiAssert.informationalItems, hasLength(1));
+        expect(
+          multiAssert.informationalItems.single.reason,
+          contains('assert-only constructor body dropped'),
+        );
+        expect(
+          multiAssert.fields.map((f) => f.name).toList(),
+          ['left', 'top', 'width', 'height'],
+        );
+
+        // (2) Non-assert body (default-computation statement) -> stays
+        //     manual; the custom-ctor manual item is recorded.
+        final defaultComputation = models.singleWhere(
+            (m) => m.name == 'DefaultComputation');
+        expect(defaultComputation.isMigratable, isFalse,
+            reason: 'a non-assert body statement must stay manual');
+        expect(
+          defaultComputation.manualItems.any(
+            (mi) => mi.reason.contains('custom @ExchangeableObjectConstructor'),
+          ),
+          isTrue,
+        );
+        expect(defaultComputation.informationalItems, isEmpty);
+
+        // (3) Mixed assert + non-assert statements -> stays manual (not all
+        //     statements are asserts).
+        final mixed = models.singleWhere((m) => m.name == 'MixedBody');
+        expect(mixed.isMigratable, isFalse,
+            reason: 'a body with any non-assert statement must stay manual');
+        expect(
+          mixed.manualItems.any(
+            (mi) => mi.reason.contains('custom @ExchangeableObjectConstructor'),
+          ),
+          isTrue,
+        );
+
+        // (4) Empty body with @ExchangeableObjectConstructor -> converts
+        //     with NO informational note (#94 regression guard: an empty
+        //     body is not assert-only and must not emit a note).
+        final empty = models.singleWhere((m) => m.name == 'EmptyBody');
+        expect(empty.isMigratable, isTrue);
+        expect(empty.manualItems, isEmpty);
+        expect(empty.informationalItems, isEmpty,
+            reason: 'empty body must not emit an assert-only note (#94 guard)');
+      } finally {
+        scratch.deleteSync(recursive: true);
+      }
+    });
+  });
+
   group('CLI', () {
     late Directory scratch;
 

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -97,6 +97,7 @@ void main() {
       'exchangeable_object',
       'exchangeable_enum',
       'exchangeable_object_empty_ctor',
+      'exchangeable_object_assert_body',
     ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);


### PR DESCRIPTION
Fixes #99. Assert-only `@ExchangeableObjectConstructor` bodies (e.g. `UIImage_`) now convert with the asserts dropped (informational note) instead of blocking the whole class; non-assert bodies stay manual. 26/26 migrator tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved exchangeable-object migration for constructors with empty or assertion-only bodies.
  - Empty constructors now convert automatically.
  - Assertion-only constructors convert successfully and provide an informational note.
- **Bug Fixes**
  - Constructors containing other custom logic remain clearly identified as requiring manual migration.
  - Migration results now retain informational messages so important conversion details are not lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->