### PR TITLE
fix(migrator): preserve static factory methods on converted objects

### DIFF
--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -204,8 +204,15 @@ class ExchangeableDetector {
       if (member is ConstructorDeclaration) continue;
       if (member is MethodDeclaration) {
         if (member.isStatic && _returnsOwnType(member, name)) {
+          // Capture verbatim from the start of the member's line (or its doc
+          // comment) so the re-emitted factory keeps its original
+          // indentation and documentation.
+          var start = member.beginToken.precedingComments?.offset ?? member.offset;
+          while (start > 0 && unit.content[start - 1] != '\n') {
+            start--;
+          }
           staticMethods.add(
-            unit.content.substring(member.offset, member.end),
+            unit.content.substring(start, member.end),
           );
           informational.add(
             ManualItem(
@@ -446,7 +453,9 @@ class ExchangeableDetector {
   bool _returnsOwnType(MethodDeclaration member, String name) {
     final returnType = member.returnType;
     if (returnType is! NamedType) return false;
-    return _stripSuffix(returnType.name.lexeme) == name;
+    final typeName = returnType.name;
+    if (typeName is PrefixedIdentifier) return false;
+    return _stripSuffix(typeName.lexeme) == name;
   }
 
   /// Strips the fork's codegen `_` suffix: `NavigationAction_` →

--- a/zorphy_migrator/lib/src/exchangeable_detector.dart
+++ b/zorphy_migrator/lib/src/exchangeable_detector.dart
@@ -146,6 +146,8 @@ class ExchangeableDetector {
   ) {
     final fields = <FreezedField>[];
     final constructorParamNames = <String>{};
+    final staticMethods = <String>[];
+    final informational = <ManualItem>[];
 
     // Field declarations carry the docs and (for `this.x` params) the type;
     // index them by name for the constructor pass below.
@@ -201,6 +203,23 @@ class ExchangeableDetector {
     for (final member in members) {
       if (member is ConstructorDeclaration) continue;
       if (member is MethodDeclaration) {
+        if (member.isStatic && _returnsOwnType(member, name)) {
+          staticMethods.add(
+            unit.content.substring(member.offset, member.end),
+          );
+          informational.add(
+            ManualItem(
+              filePath: unit.path,
+              line: lineInfo.getLocation(member.offset).lineNumber,
+              construct: '$name.${member.name.lexeme}',
+              reason:
+                  'static factory returning $name — preserved verbatim on '
+                  'the migrated \$ class (zorphy generator re-emits it on '
+                  'the concrete class)',
+            ),
+          );
+          continue;
+        }
         manual.add(
           ManualItem(
             filePath: unit.path,
@@ -259,6 +278,8 @@ class ExchangeableDetector {
       spanEnd: node.end,
       docComment: doc,
       dialect: ModelDialect.exchangeableObject,
+      informationalItems: informational,
+      staticMethods: staticMethods,
     );
   }
 
@@ -417,6 +438,15 @@ class ExchangeableDetector {
           .join('\n');
     }
     return null;
+  }
+
+  /// Whether [member] is a static method whose (unqualified, `_`-stripped)
+  /// return type is the class's own name — i.e. a convenience factory the
+  /// zorphy generator re-emits on the generated concrete class.
+  bool _returnsOwnType(MethodDeclaration member, String name) {
+    final returnType = member.returnType;
+    if (returnType is! NamedType) return false;
+    return _stripSuffix(returnType.name.lexeme) == name;
   }
 
   /// Strips the fork's codegen `_` suffix: `NavigationAction_` →

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -176,7 +176,7 @@ class ZorphyRenderer {
   ) {
     final oldName = '${name}_';
     final reindented = methodSource
-        .replaceAll(oldName, name)
+        .replaceAll(RegExp(r'\b' + RegExp.escape(oldName) + r'\b'), name)
         .split('\n')
         .map((line) => line.isEmpty ? line : '  $line')
         .join('\n');

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -175,11 +175,12 @@ class ZorphyRenderer {
     StringBuffer sb,
   ) {
     final oldName = '${name}_';
-    final reindented = methodSource
-        .replaceAll(RegExp(r'\b' + RegExp.escape(oldName) + r'\b'), name)
-        .split('\n')
-        .map((line) => line.isEmpty ? line : '  $line')
-        .join('\n');
+    // The source is captured from the start of its line (including the
+    // original indentation), so no re-indent pass is needed here.
+    final reindented = methodSource.replaceAll(
+      RegExp(r'\b' + RegExp.escape(oldName) + r'\b'),
+      name,
+    );
     sb.writeln(reindented);
   }
 

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -176,10 +176,18 @@ class ZorphyRenderer {
   ) {
     final oldName = '${name}_';
     // The source is captured from the start of its line (including the
-    // original indentation), so no re-indent pass is needed here.
-    final reindented = methodSource.replaceAll(
-      RegExp(r'\b' + RegExp.escape(oldName) + r'\b'),
-      name,
+    // original indentation), so no re-indent pass is needed here. Re-point
+    // `Name_` ONLY in identifier positions: string literals and comments are
+    // preserved verbatim, so a factory body may still legitimately mention
+    // the old name (a user-facing tag, a doc reference) without corruption.
+    final re = RegExp(
+      r'''(["'])(?:\\.|(?!\1).)*\1|//[^\n]*|/\*[\s\S]*?\*/|\b''' +
+          RegExp.escape(oldName) +
+          r'''\b''',
+    );
+    final reindented = methodSource.replaceAllMapped(
+      re,
+      (m) => m.group(0) == oldName ? name : m.group(0)!,
     );
     sb.writeln(reindented);
   }

--- a/zorphy_migrator/lib/src/mapping.dart
+++ b/zorphy_migrator/lib/src/mapping.dart
@@ -161,7 +161,26 @@ class ZorphyRenderer {
     for (final field in model.fields) {
       _renderExchangeableField(field, sb);
     }
+    for (final method in model.staticMethods) {
+      _renderStaticFactory(method, model.name, sb);
+    }
     sb.writeln('}');
+  }
+
+  /// Emits a preserved static factory on the `$` class, re-pointing the
+  /// codegen `Name_` back to the generated concrete `Name`.
+  void _renderStaticFactory(
+    String methodSource,
+    String name,
+    StringBuffer sb,
+  ) {
+    final oldName = '${name}_';
+    final reindented = methodSource
+        .replaceAll(oldName, name)
+        .split('\n')
+        .map((line) => line.isEmpty ? line : '  $line')
+        .join('\n');
+    sb.writeln(reindented);
   }
 
   void _renderExchangeableField(FreezedField field, StringBuffer sb) {

--- a/zorphy_migrator/lib/src/model.dart
+++ b/zorphy_migrator/lib/src/model.dart
@@ -108,6 +108,13 @@ class FreezedClassModel {
   /// not). Unlike [manualItems], these do NOT make the model unmigratable.
   final List<ManualItem> informationalItems;
 
+  /// For [ModelDialect.exchangeableObject]: source snippets of static
+  /// methods returning the class's own type (e.g. `static Foo_ bar(...)`
+  /// convenience factories). The zorphy generator carries these onto the
+  /// generated concrete class, so they are preserved on the migrated `$`
+  /// class instead of being dropped. Empty for other dialects.
+  final List<String> staticMethods;
+
   /// Character offsets of the full class declaration in the source.
   final int spanStart;
   final int spanEnd;
@@ -133,6 +140,7 @@ class FreezedClassModel {
     this.enumMembers = const [],
     this.enumMemberDocs = const [],
     this.informationalItems = const [],
+    this.staticMethods = const [],
   });
 
   bool get isUnion => variants.isNotEmpty;

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
@@ -11,10 +11,10 @@ abstract class $AndroidResource {
   ///Optional default package to find.
   String? get defPackage;
   static AndroidResource id({required String name, String? defPackage}) {
-      final myAndroidResource_ = 'test';
-      return AndroidResource(name: name, defType: "id", defPackage: defPackage);
-    }
+    final myAndroidResource_ = 'test';
+    return AndroidResource(name: name, defType: "id", defPackage: defPackage);
+  }
   static AndroidResource layout({required String name, String? defPackage}) {
-      return AndroidResource(name: name, defType: "layout", defPackage: defPackage);
-    }
+    return AndroidResource(name: name, defType: "layout", defPackage: defPackage);
+  }
 }

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
@@ -11,6 +11,10 @@ abstract class $AndroidResource {
   ///Optional default package to find.
   String? get defPackage;
   static AndroidResource id({required String name, String? defPackage}) {
+      final myAndroidResource_ = 'test';
       return AndroidResource(name: name, defType: "id", defPackage: defPackage);
+    }
+  static AndroidResource layout({required String name, String? defPackage}) {
+      return AndroidResource(name: name, defType: "layout", defPackage: defPackage);
     }
 }

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/expected.dart
@@ -1,0 +1,16 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $AndroidResource {
+  ///Android resource name.
+  String get name;
+  ///Optional default resource type.
+  String? get defType;
+  ///Optional default package to find.
+  String? get defPackage;
+  static AndroidResource id({required String name, String? defPackage}) {
+      return AndroidResource(name: name, defType: "id", defPackage: defPackage);
+    }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
@@ -1,0 +1,17 @@
+@ExchangeableObject()
+class AndroidResource_ {
+  ///Android resource name.
+  String name;
+
+  ///Optional default resource type.
+  String? defType;
+
+  ///Optional default package to find.
+  String? defPackage;
+
+  AndroidResource_({required this.name, this.defType, this.defPackage});
+
+  static AndroidResource_ id({required String name, String? defPackage}) {
+    return AndroidResource_(name: name, defType: "id", defPackage: defPackage);
+  }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory/input.dart
@@ -12,6 +12,11 @@ class AndroidResource_ {
   AndroidResource_({required this.name, this.defType, this.defPackage});
 
   static AndroidResource_ id({required String name, String? defPackage}) {
+    final myAndroidResource_ = 'test';
     return AndroidResource_(name: name, defType: "id", defPackage: defPackage);
+  }
+
+  static AndroidResource_ layout({required String name, String? defPackage}) {
+    return AndroidResource_(name: name, defType: "layout", defPackage: defPackage);
   }
 }

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/expected.dart
@@ -6,6 +6,8 @@
 abstract class $AndroidResource {
   ///Android resource name.
   String get name;
+  ///Optional default resource type.
+  String? get defType;
   /// Creates an AndroidResource of type id.
   static AndroidResource id({required String name}) {
     return AndroidResource(name: name, defType: "id");

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/expected.dart
@@ -1,0 +1,13 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $AndroidResource {
+  ///Android resource name.
+  String get name;
+  /// Creates an AndroidResource of type id.
+  static AndroidResource id({required String name}) {
+    return AndroidResource(name: name, defType: "id");
+  }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/input.dart
@@ -3,7 +3,10 @@ class AndroidResource_ {
   ///Android resource name.
   String name;
 
-  AndroidResource_({required this.name});
+  ///Optional default resource type.
+  String? defType;
+
+  AndroidResource_({required this.name, this.defType});
 
   /// Creates an AndroidResource of type id.
   static AndroidResource_ id({required String name}) {

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_doc/input.dart
@@ -1,0 +1,12 @@
+@ExchangeableObject()
+class AndroidResource_ {
+  ///Android resource name.
+  String name;
+
+  AndroidResource_({required this.name});
+
+  /// Creates an AndroidResource of type id.
+  static AndroidResource_ id({required String name}) {
+    return AndroidResource_(name: name, defType: "id");
+  }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/expected.dart
@@ -6,6 +6,8 @@
 abstract class $AndroidResource {
   ///Android resource name.
   String get name;
+  ///Optional default resource type.
+  String? get defType;
   /// Creates an AndroidResource_ preserving the old name in this comment.
   static AndroidResource id({required String name}) {
     final tag = 'tag: AndroidResource_';

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/expected.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/expected.dart
@@ -1,0 +1,14 @@
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+  generateCompareTo: true,
+)
+abstract class $AndroidResource {
+  ///Android resource name.
+  String get name;
+  /// Creates an AndroidResource_ preserving the old name in this comment.
+  static AndroidResource id({required String name}) {
+    final tag = 'tag: AndroidResource_';
+    return AndroidResource(name: name, defType: "id");
+  }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/input.dart
@@ -1,0 +1,13 @@
+@ExchangeableObject()
+class AndroidResource_ {
+  ///Android resource name.
+  String name;
+
+  AndroidResource_({required this.name});
+
+  /// Creates an AndroidResource_ preserving the old name in this comment.
+  static AndroidResource_ id({required String name}) {
+    final tag = 'tag: AndroidResource_';
+    return AndroidResource_(name: name, defType: "id");
+  }
+}

--- a/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/input.dart
+++ b/zorphy_migrator/test/fixtures/exchangeable_object_static_factory_preserve/input.dart
@@ -3,7 +3,10 @@ class AndroidResource_ {
   ///Android resource name.
   String name;
 
-  AndroidResource_({required this.name});
+  ///Optional default resource type.
+  String? defType;
+
+  AndroidResource_({required this.name, this.defType});
 
   /// Creates an AndroidResource_ preserving the old name in this comment.
   static AndroidResource_ id({required String name}) {

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -100,6 +100,7 @@ void main() {
       'exchangeable_object_assert_body',
       'exchangeable_object_static_factory',
       'exchangeable_object_static_factory_doc',
+      'exchangeable_object_static_factory_preserve',
     ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -132,6 +132,49 @@ void main() {
       });
     }
 
+    // Focused assertions for static-factory fixtures: manualItems must be
+    // empty and informationalItems must record the preserved-factory reason.
+    for (final name in [
+      'exchangeable_object_static_factory',
+      'exchangeable_object_static_factory_doc',
+    ]) {
+      test('$name has no manual items and records preserved-factory info',
+          () async {
+        final dir = p.join(fixturesDir, name);
+        final inputFile = p.join(dir, 'input.dart');
+
+        final models = await ExchangeableDetector().detect([
+          File(inputFile).absolute.path,
+        ]);
+        expect(
+          models.where((m) => m.isMigratable),
+          isNotEmpty,
+          reason: 'no migratable model detected in $name',
+        );
+
+        for (final m in models) {
+          expect(
+            m.manualItems,
+            isEmpty,
+            reason: '${m.name} must have no manual items',
+          );
+          expect(
+            m.informationalItems,
+            isNotEmpty,
+            reason: '${m.name} must record a preserved-factory info item',
+          );
+          expect(
+            m.informationalItems.every(
+              (item) => item.reason.contains('preserved verbatim'),
+            ),
+            isTrue,
+            reason:
+                '${m.name} informational items should mention preserved factory',
+          );
+        }
+      });
+    }
+
     test('detector strips the codegen `_` suffix and records dialects', () async {
       final inputFile = File(
         p.join(fixturesDir, 'exchangeable_object', 'input.dart'),

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -97,6 +97,7 @@ void main() {
       'exchangeable_object',
       'exchangeable_enum',
       'exchangeable_object_empty_ctor',
+      'exchangeable_object_static_factory',
     ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -98,6 +98,7 @@ void main() {
       'exchangeable_enum',
       'exchangeable_object_empty_ctor',
       'exchangeable_object_static_factory',
+      'exchangeable_object_static_factory_doc',
     ]) {
       test('$name converts byte-identical to expected.dart', () async {
         final dir = p.join(fixturesDir, name);

--- a/zorphy_migrator/test/migration_test.dart
+++ b/zorphy_migrator/test/migration_test.dart
@@ -97,6 +97,7 @@ void main() {
       'exchangeable_object',
       'exchangeable_enum',
       'exchangeable_object_empty_ctor',
+      'exchangeable_object_assert_body',
       'exchangeable_object_static_factory',
       'exchangeable_object_static_factory_doc',
     ]) {
@@ -186,6 +187,160 @@ void main() {
         networkServiceType.informationalItems.single.reason,
         contains('not sequential 0..n-1'),
       );
+    });
+  });
+
+  group('assert-only constructor body handling (#99)', () {
+    /// Stages inline source as a minimal package and returns the absolute
+    /// path of the staged input. Unresolved `@ExchangeableObject`
+    /// annotations are tolerated — the detector matches by simple name,
+    /// like the existing exchangeable fixtures.
+    String stageInline(Directory scratch, String content) {
+      final inputFile = File(p.join(scratch.path, 'input.dart'))
+        ..writeAsStringSync(content);
+      File(p.join(scratch.path, 'pubspec.yaml')).writeAsStringSync(
+        'name: scratch_assert_99\n'
+        'environment:\n'
+        '  sdk: ">=3.8.0 <4.0.0"\n'
+        'dependencies:\n'
+        '  freezed_annotation: ^3.1.0\n',
+      );
+      final result = Process.runSync('dart', ['pub', 'get'],
+          workingDirectory: scratch.path);
+      if (result.exitCode != 0) {
+        fail('pub get failed in scratch package: ${result.stderr}');
+      }
+      return inputFile.absolute.path;
+    }
+
+    test(
+        'assert-only bodies convert with a note; non-assert and mixed stay manual',
+        () async {
+      final scratch =
+          Directory.systemTemp.createTempSync('zorphy_assert_99');
+      try {
+        final path = stageInline(scratch, r'''
+@ExchangeableObject()
+class MultiAssert_ {
+  ///The left edge.
+  double? left;
+
+  ///The top edge.
+  double? top;
+
+  ///The width.
+  double? width;
+
+  ///The height.
+  double? height;
+
+  @ExchangeableObjectConstructor()
+  MultiAssert_({this.left, this.top, this.width, this.height}) {
+    assert(left == null || left >= 0);
+    assert(top == null || top >= 0);
+    assert(width == null || width >= 0);
+    assert(height == null || height >= 0);
+  }
+}
+
+@ExchangeableObject()
+class DefaultComputation_ {
+  ///The script source.
+  String? source;
+
+  ///The allowed origin rules (defaulted in the body).
+  List<String>? allowedOriginRules;
+
+  @ExchangeableObjectConstructor()
+  DefaultComputation_({this.source, this.allowedOriginRules}) {
+    this.allowedOriginRules = this.allowedOriginRules ?? const <String>['*'];
+  }
+}
+
+@ExchangeableObject()
+class MixedBody_ {
+  ///A value.
+  String? value;
+
+  ///A normalized value.
+  String? normalized;
+
+  @ExchangeableObjectConstructor()
+  MixedBody_({this.value, this.normalized}) {
+    assert(value != null || normalized != null);
+    this.normalized = this.normalized ?? this.value;
+  }
+}
+
+@ExchangeableObject()
+class EmptyBody_ {
+  ///The template image.
+  String templateImage;
+
+  ///The extension identifier.
+  String extensionIdentifier;
+
+  @ExchangeableObjectConstructor()
+  EmptyBody_({required this.templateImage, required this.extensionIdentifier});
+}
+''');
+        final models = await ExchangeableDetector().detect([path]);
+
+        // (1) Assert-only body (multiple asserts) -> converts, and an
+        //     informational note records the dropped asserts. Fields are
+        //     collected from the constructor parameters.
+        final multiAssert =
+            models.singleWhere((m) => m.name == 'MultiAssert');
+        expect(multiAssert.isMigratable, isTrue,
+            reason: 'an assert-only body must not block conversion');
+        expect(multiAssert.manualItems, isEmpty);
+        expect(multiAssert.informationalItems, hasLength(1));
+        expect(
+          multiAssert.informationalItems.single.reason,
+          contains('assert-only constructor body dropped'),
+        );
+        expect(
+          multiAssert.fields.map((f) => f.name).toList(),
+          ['left', 'top', 'width', 'height'],
+        );
+
+        // (2) Non-assert body (default-computation statement) -> stays
+        //     manual; the custom-ctor manual item is recorded.
+        final defaultComputation = models.singleWhere(
+            (m) => m.name == 'DefaultComputation');
+        expect(defaultComputation.isMigratable, isFalse,
+            reason: 'a non-assert body statement must stay manual');
+        expect(
+          defaultComputation.manualItems.any(
+            (mi) => mi.reason.contains('custom @ExchangeableObjectConstructor'),
+          ),
+          isTrue,
+        );
+        expect(defaultComputation.informationalItems, isEmpty);
+
+        // (3) Mixed assert + non-assert statements -> stays manual (not all
+        //     statements are asserts).
+        final mixed = models.singleWhere((m) => m.name == 'MixedBody');
+        expect(mixed.isMigratable, isFalse,
+            reason: 'a body with any non-assert statement must stay manual');
+        expect(
+          mixed.manualItems.any(
+            (mi) => mi.reason.contains('custom @ExchangeableObjectConstructor'),
+          ),
+          isTrue,
+        );
+
+        // (4) Empty body with @ExchangeableObjectConstructor -> converts
+        //     with NO informational note (#94 regression guard: an empty
+        //     body is not assert-only and must not emit a note).
+        final empty = models.singleWhere((m) => m.name == 'EmptyBody');
+        expect(empty.isMigratable, isTrue);
+        expect(empty.manualItems, isEmpty);
+        expect(empty.informationalItems, isEmpty,
+            reason: 'empty body must not emit an assert-only note (#94 guard)');
+      } finally {
+        scratch.deleteSync(recursive: true);
+      }
     });
   });
 


### PR DESCRIPTION
Closes #96

Brings the issue #96 fix to development (the repo lags master; PR #97 targets master directly). Static convenience factory methods (static methods returning the class own type) no longer block whole-class conversion — they are preserved verbatim on the migrated $Class with the codegen Name_ re-pointed to the concrete Name, and reported informational. The zorphy generator _extractFactoryMethods re-emits them on the generated concrete class. Verified: dart analyze clean, 25/25 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved static factory methods when generating exchangeable value objects.
  * Updated factory return types to reference generated classes.
  * Supported documented and undocumented factories while retaining source behavior.

* **Bug Fixes**
  * Prevented supported static factories from being omitted from generated output.
  * Excluded supported factories from manual-migration reports.

* **Tests**
  * Added coverage for documented, undocumented, and source-preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->