### PR TITLE
feat(json): customizable polymorphic dispatch — typeKey + subtypeWireValue (closes #103)

### DIFF
--- a/zorphy/example/lib/src/domain/entities/display_mode/default_mode.dart
+++ b/zorphy/example/lib/src/domain/entities/display_mode/default_mode.dart
@@ -1,0 +1,13 @@
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+import 'display_mode.dart';
+
+part 'default_mode.zorphy.dart';
+part 'default_mode.g.dart';
+
+/// Default TWA display mode — wire value `DEFAULT_MODE`.
+@Zorphy(generateJson: true, subtypeWireValue: 'DEFAULT_MODE')
+abstract class $DefaultMode implements $DisplayMode {
+  @override
+  String get name => 'DEFAULT_MODE';
+}

--- a/zorphy/example/lib/src/domain/entities/display_mode/display_mode.dart
+++ b/zorphy/example/lib/src/domain/entities/display_mode/display_mode.dart
@@ -1,0 +1,27 @@
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+import 'immersive_mode.dart';
+import 'default_mode.dart';
+
+part 'display_mode.zorphy.dart';
+part 'display_mode.g.dart';
+
+/// Polymorphic base for Android TWA display modes.
+///
+/// Wire contract (native Android): `{"type": "DEFAULT_MODE" | "IMMERSIVE_MODE"}`
+/// — the discriminator key is `type` (NOT the zorphy default `__typename`),
+/// and the wire values are upper-case constants (NOT the Dart class names).
+///
+/// This is the exact scenario issue #103 was filed for: the structure is
+/// expressible in zorphy, but the generated `__typename` + class-name wire
+/// would break the platform boundary. With `typeKey` + `subtypeWireValue`
+/// the native contract is preserved verbatim.
+@Zorphy(
+  generateJson: true,
+  explicitSubTypes: [$DefaultMode, $ImmersiveMode],
+  nonSealed: true,
+  typeKey: 'type',
+)
+abstract class $DisplayMode {
+  String get name;
+}

--- a/zorphy/example/lib/src/domain/entities/display_mode/immersive_mode.dart
+++ b/zorphy/example/lib/src/domain/entities/display_mode/immersive_mode.dart
@@ -1,0 +1,13 @@
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+import 'display_mode.dart';
+
+part 'immersive_mode.zorphy.dart';
+part 'immersive_mode.g.dart';
+
+/// Immersive TWA display mode — wire value `IMMERSIVE_MODE`.
+@Zorphy(generateJson: true, subtypeWireValue: 'IMMERSIVE_MODE')
+abstract class $ImmersiveMode implements $DisplayMode {
+  @override
+  String get name => 'IMMERSIVE_MODE';
+}

--- a/zorphy/example/pubspec.lock
+++ b/zorphy/example/pubspec.lock
@@ -471,13 +471,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.0.0"
   zorphy_annotation:
     dependency: "direct main"
     description:
       path: "../../zorphy_annotation"
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.0.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/lib/src/analysis/annotation_parser.dart
+++ b/zorphy/lib/src/analysis/annotation_parser.dart
@@ -31,6 +31,8 @@ class AnnotationParser {
           .peek('hidePublicConstructor')
           ?.boolValue,
       nonSealed: annotation.peek('nonSealed')?.boolValue,
+      typeKey: annotation.peek('typeKey')?.stringValue,
+      subtypeWireValue: annotation.peek('subtypeWireValue')?.stringValue,
     );
   }
 
@@ -80,6 +82,8 @@ class AnnotationOptions {
   final bool? generateChangeTo;
   final bool? hidePublicConstructor;
   final bool? nonSealed;
+  final String? typeKey;
+  final String? subtypeWireValue;
 
   /// Creates a typed options object from annotation values.
   const AnnotationOptions({
@@ -98,5 +102,7 @@ class AnnotationOptions {
     this.generateChangeTo,
     this.hidePublicConstructor,
     this.nonSealed,
+    this.typeKey,
+    this.subtypeWireValue,
   });
 }

--- a/zorphy/lib/src/analysis/class_analyzer.dart
+++ b/zorphy/lib/src/analysis/class_analyzer.dart
@@ -24,6 +24,16 @@ class ClassAnalyzer {
     final isAbstract = className.startsWith(r'$$');
     final nonSealed = annotation.read('nonSealed').boolValue;
     final isSealed = isAbstract && !nonSealed;
+    // typeKey: own value takes precedence; otherwise inherit from the
+    // nearest @Zorphy/@Zorphy2-annotated supertype that declares
+    // explicitSubTypes. Subtypes inherit so the generated subtype
+    // toJson() emits the same discriminator key the base's fromJson
+    // dispatches on.
+    final typeKey = annotation.peek('typeKey')?.stringValue ??
+        _resolveInheritedTypeKey(classElement);
+    // subtypeWireValue: per-subtype override of the wire value the base
+    // emits/matches for this subtype. Null -> clean class name at codegen.
+    final subtypeWireValue = annotation.peek('subtypeWireValue')?.stringValue;
 
     // Validate that class uses implements, not extends
     _validateClassStructure(classElement);
@@ -71,6 +81,8 @@ class ClassAnalyzer {
       isAbstract: isAbstract,
       isSealed: isSealed,
       nonSealed: nonSealed,
+      typeKey: typeKey,
+      subtypeWireValue: subtypeWireValue,
       hasConstConstructor: classElement.constructors.any((e) => e.isConst),
       docComment: classElement.documentationComment ?? '',
       generics: generics,
@@ -211,6 +223,11 @@ class ClassAnalyzer {
           .map((f) => NameType(f.name, f.type ?? ""))
           .toList();
 
+      // Read the subtype's own @Zorphy(subtypeWireValue: ...) so the
+      // base's dispatch can match the wire value the remote API sends.
+      // Defaults to null -> clean class name (resolved at codegen time).
+      final subtypeWireValue =
+          _readSubtypeAnnotation(el)?.peek('subtypeWireValue')?.stringValue;
       return Interface.fromGenerics(
         el.name ?? "",
         el.typeParameters.map((tp) {
@@ -222,6 +239,9 @@ class ClassAnalyzer {
         }).toList(),
         nameTypeFields,
         true,
+        false,
+        false,
+        subtypeWireValue,
       );
     }).toList();
   }
@@ -401,5 +421,52 @@ class ClassAnalyzer {
     Set<String> classesInExplicitSubtypes,
   ) {
     return classesInExplicitSubtypes.contains(className);
+  }
+
+  /// Walks [classElement]'s supertype chain to find the nearest
+  /// `@Zorphy`/`@Zorphy2`-annotated base that declares `explicitSubTypes`,
+  /// and returns that base's `typeKey`. Returns `null` when no such base
+  /// exists or the base didn't customize its `typeKey`.
+  ///
+  /// Subtypes inherit the base's `typeKey` so the generated subtype
+  /// `toJson()` emits the same discriminator key the base's `fromJson`
+  /// dispatches on.
+  static String? _resolveInheritedTypeKey(ClassElement classElement) {
+    final zorphyChecker = const TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/annotations.dart#Zorphy',
+    );
+    final zorphy2Checker = const TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/annotations.dart#Zorphy2',
+    );
+    for (final supertype in classElement.allSupertypes) {
+      final el = supertype.element;
+      if (el is! ClassElement) continue;
+      final annot = zorphyChecker.firstAnnotationOf(el) ??
+          zorphy2Checker.firstAnnotationOf(el);
+      if (annot == null) continue;
+      final reader = ConstantReader(annot);
+      final subs = reader.peek('explicitSubTypes');
+      if (subs == null || subs.isNull) continue;
+      // Found the polymorphic base - return its typeKey (may still be null).
+      return reader.peek('typeKey')?.stringValue;
+    }
+    return null;
+  }
+
+  /// Returns a [ConstantReader] for the first `@Zorphy` or `@Zorphy2`
+  /// annotation on [el], or `null` when the class isn't annotated.
+  ///
+  /// Used by [_extractExplicitSubtypes] to read each subtype's
+  /// `subtypeWireValue` regardless of which annotation flavor it uses.
+  static ConstantReader? _readSubtypeAnnotation(ClassElement el) {
+    final zorphyChecker = const TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/annotations.dart#Zorphy',
+    );
+    final zorphy2Checker = const TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/annotations.dart#Zorphy2',
+    );
+    final annot = zorphyChecker.firstAnnotationOf(el) ??
+        zorphy2Checker.firstAnnotationOf(el);
+    return annot == null ? null : ConstantReader(annot);
   }
 }

--- a/zorphy/lib/src/common/classes.dart
+++ b/zorphy/lib/src/common/classes.dart
@@ -14,6 +14,10 @@ class Interface {
   /// If true the interface has hidePublicConstructor: true
   final bool hidePublicConstructor;
 
+  /// Custom wire value for polymorphic JSON dispatch.
+  /// When null, [interfaceName] (stripped of $ prefix) is used.
+  final String? wireValue;
+
   /// Creates an interface descriptor from generic names and bounds.
   Interface(
     this.interfaceName,
@@ -23,6 +27,7 @@ class Interface {
     this.isExplicitSubType = false,
     this.isSealed = false,
     this.hidePublicConstructor = false,
+    this.wireValue,
   ]) : assert(
          genericExtends.length == genericName.length,
          "typeArgs must have same length as typeParams",
@@ -40,6 +45,7 @@ class Interface {
     this.isExplicitSubType = false,
     this.isSealed = false,
     this.hidePublicConstructor = false,
+    this.wireValue,
   ]);
 
   /// Returns a compact string representation of the interface.

--- a/zorphy/lib/src/generators/json_generator.dart
+++ b/zorphy/lib/src/generators/json_generator.dart
@@ -115,6 +115,14 @@ class JsonGenerator extends UniversalGenerator {
     GenerationConfig config,
   ) {
     final className = metadata.cleanName;
+    // Effective discriminator key: the base's `typeKey`
+    // (inherited by subtypes via ClassAnalyzer._resolveInheritedTypeKey)
+    // or the historical default `'__typename'`.
+    final typeKey = metadata.typeKey ?? '__typename';
+    // Self-case wire value: a non-sealed base (or a base that is itself
+    // a subtype) must emit/match the same value its own `toJson()`
+    // produces. Falls back to the clean class name.
+    final selfWireValue = metadata.subtypeWireValue ?? className;
     final bodyLines = <String>[];
 
     final hasSelfCase = !metadata.isAbstract &&
@@ -125,7 +133,7 @@ class JsonGenerator extends UniversalGenerator {
 
     if (hasSelfCase) {
       bodyLines.add(
-          "if (json['__typename'] == null || json['__typename'] == '$className') {");
+          "if (json['$typeKey'] == null || json['$typeKey'] == '$selfWireValue') {");
       bodyLines.add('  return _\$${className}FromJson(json);');
       caseIndex++;
     }
@@ -135,6 +143,9 @@ class JsonGenerator extends UniversalGenerator {
       // Strip leading `$` from interface names (e.g. `$CreditCard` → `CreditCard`)
       // so the generated code references valid Dart identifiers.
       final interfaceName = subtype.interfaceName.replaceAll('\$', '');
+      // Per-subtype wire value: `subtypeWireValue` override on the subtype,
+      // else the clean interface name.
+      final wireValue = subtype.wireValue ?? interfaceName;
       final isLast = caseIndex == totalCases - 1;
       final prefix = caseIndex == 0 ? 'if' : '} else if';
 
@@ -142,7 +153,7 @@ class JsonGenerator extends UniversalGenerator {
         final genericTypes =
             subtype.typeParams.map((e) => "'\$\${e.name}\$'").join(',');
         bodyLines.add(
-            "$prefix (json['__typename'] == '$interfaceName') {");
+            "$prefix (json['$typeKey'] == '$wireValue') {");
         bodyLines.add('  var fn_fromJson = getFromJsonToGenericFn(');
         bodyLines.add('    ${interfaceName}_Generics_Sing().fns,');
         bodyLines.add('    json,');
@@ -151,7 +162,7 @@ class JsonGenerator extends UniversalGenerator {
         bodyLines.add('  return fn_fromJson(json);');
       } else {
         bodyLines.add(
-            "$prefix (json['__typename'] == '$interfaceName') {");
+            "$prefix (json['$typeKey'] == '$wireValue') {");
         bodyLines.add('  return $interfaceName.fromJson(json);');
       }
       if (isLast) bodyLines.add('}');
@@ -159,7 +170,7 @@ class JsonGenerator extends UniversalGenerator {
     }
 
     bodyLines.add(
-        "throw UnsupportedError(\"The __typename '\${json['__typename']}' is not supported by the $className.fromJson constructor.\");");
+        "throw UnsupportedError(\"The $typeKey '\${json['$typeKey']}' is not supported by the $className.fromJson constructor.\");");
 
     specs.add(ClassMemberCode.constructor(Constructor((c) {
       c.factory = true;
@@ -179,10 +190,12 @@ class JsonGenerator extends UniversalGenerator {
             metadata.explicitSubtypes[i];
         // Strip leading `$` from interface names.
         final subtypeName = subtype.interfaceName.replaceAll('\$', '');
+        // Per-subtype wire value (subtypeWireValue override or clean name).
+        final wireValue = subtype.wireValue ?? subtypeName;
         final keyword = i == 0 ? 'if' : '} else if';
         toJsonBody.add('  $keyword (this is $subtypeName) {');
         toJsonBody.add('    final json = (this as $subtypeName).toJsonLean();');
-        toJsonBody.add("    json['__typename'] = '$subtypeName';");
+        toJsonBody.add("    json['$typeKey'] = '$wireValue';");
         toJsonBody.add('    return json;');
       }
       if (metadata.explicitSubtypes.isNotEmpty) toJsonBody.add('  }');
@@ -191,7 +204,7 @@ class JsonGenerator extends UniversalGenerator {
             '  throw UnsupportedError("Unknown subtype: \\\$runtimeType");');
       } else {
         toJsonBody.add('  final json = toJsonLean();');
-        toJsonBody.add("  json['__typename'] = '$className';");
+        toJsonBody.add("  json['$typeKey'] = '$selfWireValue';");
         toJsonBody.add('  return json;');
       }
 
@@ -337,6 +350,10 @@ class JsonGenerator extends UniversalGenerator {
     }
 
     // _sanitizeJson method
+    // Strips THIS class's own discriminator key (default `'__typename'`)
+    // from the payload and any nested maps so it doesn't leak into wire
+    // output where the discriminator is only meaningful at the top level.
+    final sanitizeTypeKey = metadata.typeKey ?? '__typename';
     specs.add(Method((m) {
       m.name = '_sanitizeJson';
       m.returns = referType('dynamic');
@@ -345,7 +362,7 @@ class JsonGenerator extends UniversalGenerator {
         p.type = referType('dynamic');
       }));
       m.body = Code('''if (json is Map<String, dynamic>) {
-  json.remove('__typename');
+  json.remove('$sanitizeTypeKey');
   return json..forEach((key, value) {
     json[key] = _sanitizeJson(value);
   });
@@ -361,9 +378,15 @@ return json;''');
   void _addToJsonWithDiscriminator(
       List<Spec> specs, ClassMetadata metadata) {
     final className = metadata.cleanName;
+    // Effective key: inherited from the base (resolved by ClassAnalyzer)
+    // or the default `'__typename'`.
+    final typeKey = metadata.typeKey ?? '__typename';
+    // Effective wire value for THIS subtype: the explicit override or
+    // the clean class name.
+    final wireValue = metadata.subtypeWireValue ?? className;
     final body = <String>[];
     body.add('final json = _\$$className' + 'ToJson(this);');
-    body.add("json['__typename'] = '$className';");
+    body.add("json['$typeKey'] = '$wireValue';");
     body.add('return json;');
     specs.add(ClassMemberCode.method(Method((m) {
       m.name = 'toJson';

--- a/zorphy/lib/src/generators/json_generator.dart
+++ b/zorphy/lib/src/generators/json_generator.dart
@@ -6,6 +6,19 @@ import '../models/class_metadata.dart';
 import '../models/generation_config.dart';
 import 'base_generator.dart';
 
+/// Escapes a string value for safe interpolation into a Dart string literal.
+/// Handles apostrophes, backslashes, quotes, dollar signs, and line breaks.
+String _escapeDartStringLiteral(String value) {
+  return value
+      .replaceAll('\\', '\\\\')  // backslash must be first
+      .replaceAll("'", "\\'")     // single quote
+      .replaceAll('"', '\\"')     // double quote
+      .replaceAll('\$', '\\\$')   // dollar sign
+      .replaceAll('\n', '\\n')    // newline
+      .replaceAll('\r', '\\r')    // carriage return
+      .replaceAll('\t', '\\t');   // tab
+}
+
 /// Generates JSON serialization members.
 ///
 /// - `fromJson` (factory constructor) is returned as
@@ -83,7 +96,7 @@ class JsonGenerator extends UniversalGenerator {
               manualFromJsonFields.where((m) => m.name == f.name);
           if (manualField.isNotEmpty) {
             final info = manualField.first.jsonKeyInfo!;
-            final jsonFieldName = info.name ?? f.name;
+            final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
             bodyLines.add(
                 "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
           } else {
@@ -118,11 +131,11 @@ class JsonGenerator extends UniversalGenerator {
     // Effective discriminator key: the base's `typeKey`
     // (inherited by subtypes via ClassAnalyzer._resolveInheritedTypeKey)
     // or the historical default `'__typename'`.
-    final typeKey = metadata.typeKey ?? '__typename';
+    final typeKey = _escapeDartStringLiteral(metadata.typeKey ?? '__typename');
     // Self-case wire value: a non-sealed base (or a base that is itself
     // a subtype) must emit/match the same value its own `toJson()`
     // produces. Falls back to the clean class name.
-    final selfWireValue = metadata.subtypeWireValue ?? className;
+    final selfWireValue = _escapeDartStringLiteral(metadata.subtypeWireValue ?? className);
     final bodyLines = <String>[];
 
     final hasSelfCase = !metadata.isAbstract &&
@@ -145,7 +158,7 @@ class JsonGenerator extends UniversalGenerator {
       final interfaceName = subtype.interfaceName.replaceAll('\$', '');
       // Per-subtype wire value: `subtypeWireValue` override on the subtype,
       // else the clean interface name.
-      final wireValue = subtype.wireValue ?? interfaceName;
+      final wireValue = _escapeDartStringLiteral(subtype.wireValue ?? interfaceName);
       final isLast = caseIndex == totalCases - 1;
       final prefix = caseIndex == 0 ? 'if' : '} else if';
 
@@ -191,7 +204,7 @@ class JsonGenerator extends UniversalGenerator {
         // Strip leading `$` from interface names.
         final subtypeName = subtype.interfaceName.replaceAll('\$', '');
         // Per-subtype wire value (subtypeWireValue override or clean name).
-        final wireValue = subtype.wireValue ?? subtypeName;
+        final wireValue = _escapeDartStringLiteral(subtype.wireValue ?? subtypeName);
         final keyword = i == 0 ? 'if' : '} else if';
         toJsonBody.add('  $keyword (this is $subtypeName) {');
         toJsonBody.add('    final json = (this as $subtypeName).toJsonLean();');
@@ -255,7 +268,7 @@ class JsonGenerator extends UniversalGenerator {
             manualFromJsonFields.where((m) => m.name == f.name);
         if (manualField.isNotEmpty) {
           final info = manualField.first.jsonKeyInfo!;
-          final jsonFieldName = info.name ?? f.name;
+          final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
           bodyLines.add(
               "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
         } else {
@@ -311,7 +324,7 @@ class JsonGenerator extends UniversalGenerator {
               'ToJson(this);');
       for (final f in manualToJsonFields) {
         final info = f.jsonKeyInfo!;
-        final jsonFieldName = info.name ?? f.name;
+        final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
         body.add(
             "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
       }
@@ -330,7 +343,7 @@ class JsonGenerator extends UniversalGenerator {
               'ToJson(this, $toJsonArgs);');
       for (final f in manualToJsonFields) {
         final info = f.jsonKeyInfo!;
-        final jsonFieldName = info.name ?? f.name;
+        final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
         body.add(
             "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
       }
@@ -353,7 +366,7 @@ class JsonGenerator extends UniversalGenerator {
     // Strips THIS class's own discriminator key (default `'__typename'`)
     // from the payload and any nested maps so it doesn't leak into wire
     // output where the discriminator is only meaningful at the top level.
-    final sanitizeTypeKey = metadata.typeKey ?? '__typename';
+    final sanitizeTypeKey = _escapeDartStringLiteral(metadata.typeKey ?? '__typename');
     specs.add(Method((m) {
       m.name = '_sanitizeJson';
       m.returns = referType('dynamic');
@@ -380,10 +393,10 @@ return json;''');
     final className = metadata.cleanName;
     // Effective key: inherited from the base (resolved by ClassAnalyzer)
     // or the default `'__typename'`.
-    final typeKey = metadata.typeKey ?? '__typename';
+    final typeKey = _escapeDartStringLiteral(metadata.typeKey ?? '__typename');
     // Effective wire value for THIS subtype: the explicit override or
     // the clean class name.
-    final wireValue = metadata.subtypeWireValue ?? className;
+    final wireValue = _escapeDartStringLiteral(metadata.subtypeWireValue ?? className);
     final body = <String>[];
     body.add('final json = _\$$className' + 'ToJson(this);');
     body.add("json['$typeKey'] = '$wireValue';");
@@ -480,7 +493,7 @@ class JsonExtensionGenerator extends ConcreteClassGenerator {
         body.add('final data = _\$$className' + 'ToJson(this);');
         for (final f in manualToJsonFields) {
           final info = f.jsonKeyInfo!;
-          final jsonFieldName = info.name ?? f.name;
+          final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
           body.add(
               "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
         }
@@ -514,7 +527,7 @@ class JsonExtensionGenerator extends ConcreteClassGenerator {
             'final data = _\$$className' + 'ToJson(this, $toJsonArgs);');
         for (final f in manualToJsonFields) {
           final info = f.jsonKeyInfo!;
-          final jsonFieldName = info.name ?? f.name;
+          final jsonFieldName = _escapeDartStringLiteral(info.name ?? f.name);
           body.add(
               "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
         }

--- a/zorphy/lib/src/models/class_metadata.dart
+++ b/zorphy/lib/src/models/class_metadata.dart
@@ -21,6 +21,17 @@ class ClassMetadata {
   /// Whether nonSealed: true was set in annotation
   final bool nonSealed;
 
+  /// Custom JSON key for polymorphic type dispatch.
+  /// When null, `'__typename'` is used.
+  final String? typeKey;
+
+  /// Custom wire value for this subtype in the base class's polymorphic
+  /// JSON dispatch. When null, the clean class name is used.
+  ///
+  /// Only meaningful on **subtype** classes (those listed in a parent's
+  /// `explicitSubTypes`). The value must match what the remote API sends.
+  final String? subtypeWireValue;
+
   /// Whether the class has a const constructor
   final bool hasConstConstructor;
 
@@ -68,6 +79,8 @@ class ClassMetadata {
     required this.isAbstract,
     required this.isSealed,
     required this.nonSealed,
+    this.typeKey,
+    this.subtypeWireValue,
     required this.hasConstConstructor,
     required this.docComment,
     required this.generics,

--- a/zorphy/lib/src/models/generation_config.dart
+++ b/zorphy/lib/src/models/generation_config.dart
@@ -117,6 +117,10 @@ class GenerationConfig {
   /// Whether the class is abstract (not sealed) when prefixed with $$
   final bool nonSealed;
 
+  /// Custom JSON key for polymorphic type dispatch.
+  /// When null, `'__typename'` is used.
+  final String? typeKey;
+
   /// Factory methods for the class
   final List<FactoryMethodInfo> factoryMethods;
 
@@ -141,6 +145,7 @@ class GenerationConfig {
     required this.generateEqualsToString,
     required this.generateChangeTo,
     required this.nonSealed,
+    this.typeKey,
     required this.factoryMethods,
     required this.ownFields,
   });
@@ -214,6 +219,7 @@ class GenerationConfig {
       ),
       hidePublicConstructor: options.hidePublicConstructor ?? false,
       nonSealed: options.nonSealed ?? false,
+      typeKey: options.typeKey,
       factoryMethods: factoryMethods,
       ownFields: ownFields,
     );
@@ -284,6 +290,7 @@ class GenerationConfig {
     this.generateEqualsToString = true,
     this.generateChangeTo = true,
     this.nonSealed = false,
+    this.typeKey = null,
     this.factoryMethods = const [],
     this.ownFields = const {},
   });

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -556,11 +556,9 @@ packages:
   zorphy_annotation:
     dependency: "direct main"
     description:
-      path: zorphy_annotation
-      ref: development
-      resolved-ref: c025225997627a03163cf629be0ff4531a46500a
-      url: "https://github.com/arrrrny/zorphy.git"
-    source: git
-    version: "2.2.0"
+      path: "../zorphy_annotation"
+      relative: true
+    source: path
+    version: "2.0.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/pubspec_overrides.yaml
+++ b/zorphy/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  zorphy_annotation:
+    path: ../zorphy_annotation

--- a/zorphy/pubspec_overrides.yaml
+++ b/zorphy/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  zorphy_annotation:
-    path: ../zorphy_annotation

--- a/zorphy/test/generation/issue_103_custom_type_key_test.dart
+++ b/zorphy/test/generation/issue_103_custom_type_key_test.dart
@@ -1,0 +1,278 @@
+// Regression test for issue #103:
+// "zorphy polymorphic JSON dispatch: __typename key + class-name values
+//  are hardcoded — no way to preserve custom type-key wires"
+//
+// Verifies that:
+//  1. `@Zorphy(typeKey: 'type')` on a polymorphic base renames the
+//     discriminator key from `'__typename'` to `'type'` in BOTH
+//     `fromJson` (dispatch) and `toJson` (emit).
+//  2. `@Zorphy(subtypeWireValue: '...')` on each subtype overrides the
+//     wire value the base matches/emits (default = clean class name).
+//  3. The subtype's own `toJson()` (via _addToJsonWithDiscriminator)
+//     emits the inherited typeKey + the subtype's subtypeWireValue.
+//  4. The default behavior (no typeKey, no subtypeWireValue) is
+//     unchanged: key is `'__typename'`, values are clean class names.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy/src/ast/class_member_code.dart';
+import 'package:zorphy/src/common/classes.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/json_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Builds a polymorphic-base [ClassMetadata] with [explicitSubtypes].
+ClassMetadata _baseMeta({
+  required String name,
+  required List<Interface> subtypes,
+  String? typeKey,
+  bool nonSealed = true,
+  bool isAbstract = false,
+}) {
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: isAbstract,
+    isSealed: false,
+    nonSealed: nonSealed,
+    typeKey: typeKey,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: const [],
+    ownFieldNames: const {},
+    factoryMethods: const [],
+    explicitSubtypes: subtypes,
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+  );
+}
+
+/// Builds a subtype [ClassMetadata] (isInParentExplicitSubtypes: true).
+ClassMetadata _subtypeMeta({
+  required String name,
+  String? typeKey,
+  String? subtypeWireValue,
+}) {
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: false,
+    isSealed: false,
+    nonSealed: false,
+    typeKey: typeKey,
+    subtypeWireValue: subtypeWireValue,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: const [],
+    ownFieldNames: const {},
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: true,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+  );
+}
+
+Interface _subtype(String name, {String? wireValue}) {
+  return Interface.fromGenerics(name, [], [], true, false, false, wireValue);
+}
+
+GenerationConfig _jsonConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.entity,
+    autoId: false,
+    generateJson: true,
+    explicitToJson: true,
+    generateCopyWith: false,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: false,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: true,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+/// Emits a list of specs (ClassMemberCode + Method) into a single
+/// source string by injecting them into a synthetic Class.
+String _emitSpecs(List<Spec> specs) {
+  final constructors = <Constructor>[];
+  final methods = <Method>[];
+  for (final spec in specs) {
+    if (spec is ClassMemberCode) {
+      if (spec.constructor != null) constructors.add(spec.constructor!);
+      if (spec.method != null) methods.add(spec.method!);
+    } else if (spec is Method) {
+      methods.add(spec);
+    }
+  }
+  final cls = Class((b) => b
+    ..name = 'Synthetic'
+    ..constructors.addAll(constructors)
+    ..methods.addAll(methods));
+  final lib = Library((b) => b.body.add(cls));
+  return lib.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+}
+
+void main() {
+  final generator = JsonGenerator();
+
+  group('issue #103 — custom typeKey + subtypeWireValue', () {
+    test('base fromJson dispatches on custom typeKey with custom wire values', () {
+      // Mirrors the zikzak_inappwebview TrustedWebActivityDisplayMode contract:
+      //   {"type": "DEFAULT_MODE" | "IMMERSIVE_MODE"}
+      final meta = _baseMeta(
+        name: 'DisplayMode',
+        typeKey: 'type',
+        subtypes: [
+          _subtype('DefaultMode', wireValue: 'DEFAULT_MODE'),
+          _subtype('ImmersiveMode', wireValue: 'IMMERSIVE_MODE'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // The discriminator key MUST be the custom `type`, NOT `__typename`.
+      expect(emitted, contains("json['type']"));
+      expect(emitted, isNot(contains('__typename')));
+
+      // Each subtype's custom wire value must appear in the dispatch.
+      expect(emitted, contains("'DEFAULT_MODE'"));
+      expect(emitted, contains("'IMMERSIVE_MODE'"));
+
+      // Clean class names must NOT appear as wire values (they're overridden).
+      expect(emitted, isNot(contains("'DefaultMode'")));
+      expect(emitted, isNot(contains("'ImmersiveMode'")));
+    });
+
+    test('base toJson emits custom typeKey + custom wire values', () {
+      final meta = _baseMeta(
+        name: 'DisplayMode',
+        typeKey: 'type',
+        subtypes: [
+          _subtype('DefaultMode', wireValue: 'DEFAULT_MODE'),
+          _subtype('ImmersiveMode', wireValue: 'IMMERSIVE_MODE'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // The non-sealed polymorphic toJson must emit the custom key.
+      expect(emitted, contains("json['type'] = 'DEFAULT_MODE'"));
+      expect(emitted, contains("json['type'] = 'IMMERSIVE_MODE'"));
+      // Self-case emits the base's clean name (no subtypeWireValue on base).
+      expect(emitted, contains("json['type'] = 'DisplayMode'"));
+    });
+
+    test(
+        'subtype own toJson (via _addToJsonWithDiscriminator) uses inherited '
+        'typeKey + own subtypeWireValue', () {
+      // The subtype inherits typeKey='type' from the base (resolved by
+      // ClassAnalyzer._resolveInheritedTypeKey). In this unit test we
+      // pass the resolved value directly.
+      final meta = _subtypeMeta(
+        name: 'DefaultMode',
+        typeKey: 'type',
+        subtypeWireValue: 'DEFAULT_MODE',
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // Subtype's own toJson emits the inherited typeKey + own wire value.
+      expect(emitted, contains("json['type'] = 'DEFAULT_MODE'"));
+      expect(emitted, isNot(contains('__typename')));
+      expect(emitted, isNot(contains("'DefaultMode'")));
+    });
+
+    test('default behavior unchanged when typeKey/subtypeWireValue are null', () {
+      final meta = _baseMeta(
+        name: 'PaymentMethod',
+        subtypes: [
+          _subtype('CreditCard'),
+          _subtype('PayPal'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // Default key is __typename.
+      expect(emitted, contains("json['__typename']"));
+      // Default wire values are clean class names.
+      expect(emitted, contains("'CreditCard'"));
+      expect(emitted, contains("'PayPal'"));
+      expect(emitted, contains("'PaymentMethod'"));
+    });
+
+    test('_sanitizeJson strips the custom typeKey (not __typename)', () {
+      final meta = _baseMeta(
+        name: 'DisplayMode',
+        typeKey: 'type',
+        subtypes: [
+          _subtype('DefaultMode', wireValue: 'DEFAULT_MODE'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // _sanitizeJson must remove the custom key, not the default.
+      expect(emitted, contains("json.remove('type');"));
+      expect(emitted, isNot(contains("json.remove('__typename');")));
+    });
+
+    test('error message references the custom typeKey', () {
+      final meta = _baseMeta(
+        name: 'DisplayMode',
+        typeKey: 'type',
+        isAbstract: true,
+        nonSealed: false,
+        subtypes: [
+          _subtype('DefaultMode', wireValue: 'DEFAULT_MODE'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitSpecs(specs);
+
+      // The UnsupportedError message must use the custom key name.
+      expect(emitted, contains("The type '"));
+      expect(emitted, isNot(contains('The __typename')));
+    });
+  });
+}

--- a/zorphy_annotation/lib/src/annotations.dart
+++ b/zorphy_annotation/lib/src/annotations.dart
@@ -124,6 +124,20 @@ class Zorphy implements ZorphyX {
   /// subtypes (null = inherit from [preset])
   final bool? generateChangeTo;
 
+  /// Custom JSON key used for polymorphic type dispatch in `fromJson`
+  /// and `toJson`. When null, defaults to `'__typename'`.
+  ///
+  /// Only meaningful on the **base** class (the one that declares
+  /// `explicitSubTypes`). Subtypes inherit the base's value.
+  final String? typeKey;
+
+  /// Custom wire value for this subtype in the base class's polymorphic
+  /// JSON dispatch. When null, the clean class name is used.
+  ///
+  /// Only meaningful on **subtype** classes (those listed in a parent's
+  /// `explicitSubTypes`). The value must match what the remote API sends.
+  final String? subtypeWireValue;
+
   /// {@template ZorphyX}
   /// ### normal class; prepend class with a single dollar & make abstract
   /// ```
@@ -216,6 +230,8 @@ class Zorphy implements ZorphyX {
     this.generatePropertyHelpers = null,
     this.generateEqualsToString = null,
     this.generateChangeTo = null,
+    this.typeKey,
+    this.subtypeWireValue,
   });
 }
 
@@ -247,6 +263,12 @@ class Zorphy2 implements ZorphyX {
   final bool? generateEqualsToString;
   final bool? generateChangeTo;
 
+  /// Custom JSON key for polymorphic dispatch - see [Zorphy.typeKey].
+  final String? typeKey;
+
+  /// Custom wire value for this subtype - see [Zorphy.subtypeWireValue].
+  final String? subtypeWireValue;
+
   /// Creates a Zorphy2 annotation with configurable generation options.
   const Zorphy2({
     this.explicitSubTypes = null,
@@ -265,6 +287,8 @@ class Zorphy2 implements ZorphyX {
     this.generatePropertyHelpers = null,
     this.generateEqualsToString = null,
     this.generateChangeTo = null,
+    this.typeKey,
+    this.subtypeWireValue,
   });
 }
 
@@ -287,6 +311,12 @@ abstract class ZorphyX {
   /// Returns whether filter descriptors should be generated
   /// (null = inherit from preset).
   bool? get generateFilter;
+
+  /// Custom JSON key for polymorphic type dispatch.
+  String? get typeKey;
+
+  /// Custom wire value for this subtype in polymorphic JSON.
+  String? get subtypeWireValue;
 }
 
 /// Resolves a generic toJson function for the provided [type].


### PR DESCRIPTION
Closes #103

## Summary

zorphy's polymorphic JSON dispatch hardcoded the discriminator key () and the per-subtype wire values (clean class names). This broke seamless migration of real-world polymorphic families whose native wire contract uses a custom type key — e.g. zikzak_inappwebview's `TrustedWebActivityDisplayMode` (Android TWA contract `{"type": "DEFAULT_MODE" | "IMMERSIVE_MODE"}`).

## Changes

### New annotation options
- `@Zorphy(typeKey: "type")` — renames the discriminator key from `__typename` to `type` (or any custom name). Set on the **base** class; subtypes inherit automatically.
- `@Zorphy(subtypeWireValue: "DEFAULT_MODE")` — overrides the wire value the base matches/emits for this subtype (default = clean class name). Set on each **subtype**.

### Implementation
- `class_analyzer.dart`: resolves inherited `typeKey` by walking the supertype chain to the nearest `@Zorphy`/`@Zorphy2` base with `explicitSubTypes`; reads each subtype's `subtypeWireValue` into `Interface.wireValue`.
- `json_generator.dart`: all 7 hardcoded `__typename` literals replaced with `metadata.typeKey ?? "__typename"`; dispatch values use `subtype.wireValue ?? interfaceName`; self-case uses `metadata.subtypeWireValue ?? className`; `_sanitizeJson` strips the class's own typeKey; error message references the custom key.
- `pubspec_overrides.yaml`: path override so the generator package picks up the local annotation package with the new fields (standard monorepo pattern).

### Tests + example
- 6 new unit tests (`issue_103_custom_type_key_test.dart`) covering custom typeKey dispatch, custom wire values, subtype's own toJson, default behavior unchanged, _sanitizeJson, and error message.
- New end-to-end example (`display_mode/`) modeling the issue's TWA contract.

## Backward compatibility

Default behavior (no `typeKey`, no `subtypeWireValue`) is unchanged: key is `__typename`, values are clean class names. The existing vehicle example generates identical output.

## Verification
- `dart analyze` (zorphy + zorphy_annotation + example): clean
- `dart test`: 187/187 passed
- End-to-end: generated `DisplayMode` uses `json["type"]` with `DEFAULT_MODE`/`IMMERSIVE_MODE` wire values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing polymorphic JSON discriminator keys.
  - Added support for custom serialized values for individual subtypes.
  - Added display-mode entities for default and immersive Android TWA modes.
  - Improved generated JSON serialization and deserialization to honor configured discriminator settings, including inherited configurations.

- **Bug Fixes**
  - Improved discriminator-related error messages and handling of custom keys.

- **Tests**
  - Added coverage for custom keys, subtype values, fallback behavior, sanitization, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->