### PR TITLE
fix(generator): bare Function/Function? callback fields on value-object entities no longer break json_serializable — closes #105

### DIFF
--- a/zorphy/example/lib/various/issue_105_bare_function_field.dart
+++ b/zorphy/example/lib/various/issue_105_bare_function_field.dart
@@ -1,0 +1,39 @@
+// Repro fixture for issue #105 — value-object entity with bare
+// `Function?` callback fields (the form produced by the CLI when the
+// user writes `--field "onLoad:!Function?"` without pinning down a
+// signature).
+//
+// Mirrors the exact annotation shape from the issue:
+//   zfa entity create -n ScriptHtmlTagAttributes --kind=value_object \
+//     --field "type:String" --field "id:String?" \
+//     --field "onLoad:!Function?" --field "onError:!Function?"
+//
+// The CLI writes `Function? get onLoad;` / `Function? get onError;`
+// into the entity file. Before the #105 fix, the generator emitted
+// these as concrete `final Function? onLoad;` / `final Function? onError;`
+// on the `@JsonSerializable`-annotated class with no `@JsonKey`
+// opt-out, and `json_serializable` then failed with
+//   "Could not generate `fromJson` code for `onLoad`."
+// leaving the `.g.dart` unwritten and the package uncompilable.
+//
+// After the fix: `_isFunctionType` recognizes the bare `Function` /
+// `Function?` forms and `_effectiveJsonKeyForField` auto-emits
+// `@JsonKey(includeFromJson: false, includeToJson: false)` on each
+// callback field — exactly as it does for the fully-typed
+// `void Function(...)?` form from #89.
+
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+part 'issue_105_bare_function_field.zorphy.dart';
+part 'issue_105_bare_function_field.g.dart';
+
+@Zorphy(
+  kind: ZorphyKind.valueObject,
+  generateJson: true,
+)
+abstract class $ScriptHtmlTagAttributes {
+  String get type;
+  String? get id;
+  Function? get onLoad;
+  Function? get onError;
+}

--- a/zorphy/lib/src/generators/class_declaration_generator.dart
+++ b/zorphy/lib/src/generators/class_declaration_generator.dart
@@ -599,11 +599,12 @@ class ClassDeclarationGenerator extends UniversalGenerator {
   }
 
   // ═══════════════════════════════════════════════════════════════
-  // ISSUE #89 HELPERS — function-typed field JSON serialization
+  // ISSUE #89 / #105 HELPERS — function-typed field JSON serialization
   // ═══════════════════════════════════════════════════════════════
 
   /// Returns true when [type] is a function type (e.g.
-  /// `void Function(WebUri? url)?`, `String Function(int)`).
+  /// `void Function(WebUri? url)?`, `String Function(int)`,
+  /// or the bare `Function` / `Function?` supertype).
   ///
   /// Function-typed fields cannot be JSON-serialized by json_serializable
   /// — they need `@JsonKey(includeFromJson: false, includeToJson: false)`.
@@ -612,6 +613,21 @@ class ClassDeclarationGenerator extends UniversalGenerator {
   /// prefix. The check is intentionally permissive: it matches the
   /// existing `type.contains('Function')` heuristic used in
   /// `helpers.getPatchClass` (helpers.dart line 221).
+  ///
+  /// Issue #105: the original #89 implementation only matched
+  /// `Function(` and `Function<`, missing the BARE `Function` /
+  /// `Function?` forms. The bare form is what the CLI produces when the
+  /// user writes a callback field without pinning down a signature:
+  ///
+  ///   zfa entity create -n X --field "onLoad:!Function?"
+  ///
+  /// The CLI strips the `!` (external) marker and the trailing `?`,
+  /// writes `Function? get onLoad;` to the entity file, and the analyzer
+  /// resolves the field type to `Function?`. Without this fix, the
+  /// generator emits `final Function? onLoad;` with no `@JsonKey` →
+  /// json_serializable fails with
+  /// "Could not generate `fromJson` code for `onLoad`." and the `.g.dart`
+  /// is never written, breaking the whole package.
   bool _isFunctionType(String? type) {
     if (type == null || type.isEmpty) return false;
     // A function type always contains `Function(` (possibly with `<typeArgs>`
@@ -621,8 +637,21 @@ class ClassDeclarationGenerator extends UniversalGenerator {
     // string that contains this pattern is a function type for our purposes.
     final cleaned = type.replaceAll(' ', '');
     // Look for `Function(` or `Function<` after stripping spaces. Both forms
-    // indicate a function type.
-    return cleaned.contains('Function(') || cleaned.contains('Function<');
+    // indicate a (parameterized) function type.
+    if (cleaned.contains('Function(') || cleaned.contains('Function<')) {
+      return true;
+    }
+    // Issue #105: bare `Function` / `Function?` — the supertype of all
+    // function types. The user writes this when they want a callback slot
+    // without pinning down a signature (e.g. `--field "onLoad:!Function?"`).
+    // Match `Function` as a complete type token (NOT a substring of a
+    // larger identifier like `MyFunction` or `FunctionRef`) using word
+    // boundaries. The character class `[^A-Za-z0-9_]` matches `?`, `>`,
+    // `,`, `<`, `)`, etc., so `Function?`, `List<Function>`,
+    // `Map<String, Function?>` all hit this branch.
+    return RegExp(
+      r'(?:^|[^A-Za-z0-9_])Function(?:$|[^A-Za-z0-9_])',
+    ).hasMatch(cleaned);
   }
 
   /// Computes the effective [JsonKeyInfo] to emit for [field].

--- a/zorphy/test/generation/issue_105_bare_function_field_test.dart
+++ b/zorphy/test/generation/issue_105_bare_function_field_test.dart
@@ -1,0 +1,326 @@
+// Regression test for issue #105:
+// "generator: value-object entities with callback fields (!Function?) emit
+//  @JsonSerializable with Function fields — json_serializable errors,
+//  .g.dart never generated (uncompilable output)"
+//
+// Root cause: the #89 fix in `ClassDeclarationGenerator._isFunctionType`
+// only matched `Function(` and `Function<`. The BARE `Function` /
+// `Function?` forms — produced by the CLI when the user writes a callback
+// field without pinning down a signature (e.g.
+// `zfa entity create -n X --field "onLoad:!Function?"`) — slipped through.
+// The generator emitted `final Function? onLoad;` on the
+// `@JsonSerializable`-annotated concrete class with no `@JsonKey` opt-out,
+// `json_serializable` then errored with
+//   "Could not generate `fromJson` code for `onLoad`."
+// and the `.g.dart` was never written, breaking the whole package.
+//
+// Fix: `_isFunctionType` now also matches the bare `Function` token
+// (with word boundaries so it does not false-positive on class names like
+// `MyFunction` / `FunctionRef`). The existing `_effectiveJsonKeyForField`
+// pipeline then emits the synthetic
+// `@JsonKey(includeFromJson: false, includeToJson: false)` annotation
+// automatically, exactly as it does for `void Function(...)?` getters.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/class_declaration_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+ClassMetadata _concreteMeta({
+  required String name,
+  required List<NameTypeClassComment> fields,
+}) {
+  final ownFieldNames = fields.map((f) => f.name).toSet();
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: false,
+    isSealed: false,
+    nonSealed: false,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: fields,
+    ownFieldNames: ownFieldNames,
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+  );
+}
+
+GenerationConfig _jsonConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.valueObject,
+    autoId: false,
+    generateJson: true,
+    explicitToJson: true,
+    generateCopyWith: false,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: false,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: false,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+String _emitClass(Class spec) {
+  final lib = Library((b) => b.body.add(spec));
+  return lib.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+}
+
+void main() {
+  group('Issue #105 — bare Function/Function? callback fields on value-object', () {
+    final generator = ClassDeclarationGenerator();
+
+    test(
+      'exact issue repro: ScriptHtmlTagAttributes with onLoad/onError as Function?',
+      () {
+        // Mirrors the CLI invocation from the issue:
+        //   zfa entity create -n ScriptHtmlTagAttributes \
+        //     --kind=value_object \
+        //     --field "type:String"  --field "id:String?" \
+        //     --field "onLoad:!Function?"  --field "onError:!Function?"
+        //
+        // The CLI writes `Function? get onLoad;` / `Function? get onError;`
+        // to the entity file; the analyzer resolves both field types to
+        // the bare `Function?` type. Before the fix: emitted as
+        //   final Function? onLoad;
+        //   final Function? onError;
+        // with NO @JsonKey, causing json_serializable to fail with
+        // "Could not generate `fromJson` code for `onLoad`."
+        //
+        // After the fix: each Function? field carries
+        //   @JsonKey(includeFromJson: false, includeToJson: false)
+        // so json_serializable skips them and the .g.dart is written.
+        final meta = _concreteMeta(
+          name: 'ScriptHtmlTagAttributes',
+          fields: [
+            NameTypeClassComment('type', 'String', 'ScriptHtmlTagAttributes'),
+            NameTypeClassComment('id', 'String?', 'ScriptHtmlTagAttributes'),
+            NameTypeClassComment(
+              'onLoad',
+              'Function?',
+              'ScriptHtmlTagAttributes',
+            ),
+            NameTypeClassComment(
+              'onError',
+              'Function?',
+              'ScriptHtmlTagAttributes',
+            ),
+          ],
+        );
+        final specs = generator.generateSpec(
+          GenerationContext(metadata: meta, config: _jsonConfig()),
+        );
+        expect(specs, hasLength(1));
+        final emitted = _emitClass(specs.first as Class);
+
+        // Both callback fields MUST carry the skip-serialization JsonKey.
+        final skipKeyMatches = RegExp(
+          r'@JsonKey\(includeFromJson: false, includeToJson: false\)',
+        ).allMatches(emitted);
+        expect(skipKeyMatches, hasLength(2));
+
+        // The field declarations themselves are preserved so the
+        // abstract `$ScriptHtmlTagAttributes` interface contract is
+        // still satisfied (callbacks remain accessible at runtime).
+        expect(emitted, contains('final Function? onLoad;'));
+        expect(emitted, contains('final Function? onError;'));
+
+        // Non-callback fields are unaffected — no JsonKey on them.
+        expect(emitted, contains('final String type;'));
+        expect(emitted, contains('final String? id;'));
+        final typeJsonKeyPattern = RegExp(
+          r'@JsonKey\([^)]*\)\s*\n\s*final String type;',
+        );
+        expect(typeJsonKeyPattern.hasMatch(emitted), isFalse);
+        final idJsonKeyPattern = RegExp(
+          r'@JsonKey\([^)]*\)\s*\n\s*final String\? id;',
+        );
+        expect(idJsonKeyPattern.hasMatch(emitted), isFalse);
+      },
+    );
+
+    test('bare non-nullable `Function` is also detected', () {
+      // Some callers want a non-nullable callback slot:
+      //   --field "onReady:!Function"
+      // The CLI writes `Function get onReady;` and the analyzer resolves
+      // the type to `Function` (no `?`). This must also be detected —
+      // json_serializable cannot serialize a non-nullable `Function`
+      // field any more than a nullable one.
+      final meta = _concreteMeta(
+        name: 'Foo',
+        fields: [
+          NameTypeClassComment('id', 'String', 'Foo'),
+          NameTypeClassComment('onReady', 'Function', 'Foo'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitClass(specs.first as Class);
+
+      expect(
+        emitted,
+        contains(
+          '@JsonKey(includeFromJson: false, includeToJson: false)',
+        ),
+      );
+      expect(emitted, contains('final Function onReady;'));
+    });
+
+    test('bare `Function` nested in generics is detected', () {
+      // Edge case: `List<Function>` and `Map<String, Function?>` should
+      // also be treated as function-typed for the purposes of JSON
+      // serialization — json_serializable cannot synthesize a serializer
+      // for them either (the inner Function type is what breaks it).
+      final meta = _concreteMeta(
+        name: 'Foo',
+        fields: [
+          NameTypeClassComment('id', 'String', 'Foo'),
+          NameTypeClassComment('callbacks', 'List<Function>', 'Foo'),
+          NameTypeClassComment(
+            'namedCallbacks',
+            'Map<String, Function?>',
+            'Foo',
+          ),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitClass(specs.first as Class);
+
+      final skipKeyMatches = RegExp(
+        r'@JsonKey\(includeFromJson: false, includeToJson: false\)',
+      ).allMatches(emitted);
+      expect(skipKeyMatches, hasLength(2));
+    });
+
+    test('class names containing `Function` substring are NOT detected', () {
+      // Regression guard: the word-boundary regex must NOT match class
+      // names like `MyFunction`, `FunctionRef`, `FunctionLikeBuilder`,
+      // etc. These are plain reference types and json_serializable
+      // handles them normally (or fails for other reasons, but not with
+      // the skip-JsonKey path).
+      final meta = _concreteMeta(
+        name: 'Foo',
+        fields: [
+          NameTypeClassComment('id', 'String', 'Foo'),
+          NameTypeClassComment('handler', 'MyFunction', 'Foo'),
+          NameTypeClassComment('ref', 'FunctionRef', 'Foo'),
+          NameTypeClassComment('builder', 'FunctionLikeBuilder', 'Foo'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitClass(specs.first as Class);
+
+      // No skip-serialization JsonKey should be emitted for any of
+      // these — they are plain (non-function) types.
+      expect(
+        emitted,
+        isNot(
+          contains(
+            '@JsonKey(includeFromJson: false, includeToJson: false)',
+          ),
+        ),
+      );
+    });
+
+    test('mixed callback + data fields: only callbacks get the JsonKey', () {
+      // Realistic value-object with both data fields and callback
+      // fields. The generator must annotate ONLY the callback fields.
+      final meta = _concreteMeta(
+        name: 'BrowserMenuItem',
+        fields: [
+          NameTypeClassComment('id', 'String', 'BrowserMenuItem'),
+          NameTypeClassComment('label', 'String', 'BrowserMenuItem'),
+          NameTypeClassComment('icon', 'String?', 'BrowserMenuItem'),
+          NameTypeClassComment('onTap', 'Function?', 'BrowserMenuItem'),
+          NameTypeClassComment(
+            'onLongPress',
+            'void Function()?',
+            'BrowserMenuItem',
+          ),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _jsonConfig()),
+      );
+      final emitted = _emitClass(specs.first as Class);
+
+      // Exactly two skip-JsonKey annotations — one per callback field
+      // (the bare `Function?` and the fully-typed `void Function()?`).
+      final skipKeyMatches = RegExp(
+        r'@JsonKey\(includeFromJson: false, includeToJson: false\)',
+      ).allMatches(emitted);
+      expect(skipKeyMatches, hasLength(2));
+
+      // Data fields are emitted without the skip-JsonKey.
+      expect(emitted, contains('final String id;'));
+      expect(emitted, contains('final String label;'));
+      expect(emitted, contains('final String? icon;'));
+    });
+
+    test(
+      'user-provided @JsonKey on bare Function field is augmented',
+      () {
+        // If the user provides their own @JsonKey (e.g. with a custom
+        // wire name) on a bare `Function?` field but doesn't set
+        // includeFromJson/includeToJson, we must still add those —
+        // otherwise json_serializable will still try to generate a
+        // serializer for the bare Function type and fail.
+        final meta = _concreteMeta(
+          name: 'Foo',
+          fields: [
+            NameTypeClassComment(
+              'onLoad',
+              'Function?',
+              'Foo',
+              jsonKeyInfo: const JsonKeyInfo(name: 'on_load'),
+            ),
+          ],
+        );
+        final specs = generator.generateSpec(
+          GenerationContext(metadata: meta, config: _jsonConfig()),
+        );
+        final emitted = _emitClass(specs.first as Class);
+
+        expect(
+          emitted,
+          contains(
+            "@JsonKey(name: 'on_load', includeFromJson: false, includeToJson: false)",
+          ),
+        );
+      },
+    );
+  });
+}

--- a/zorphy/test/generation/issue_89_function_typed_getter_test.dart
+++ b/zorphy/test/generation/issue_89_function_typed_getter_test.dart
@@ -293,6 +293,8 @@ void main() {
       //   - String Function(int)
       //   - bool Function(Object)?
       //   - T Function<U>(U)  (generic function type — rare but valid)
+      //   - Function / Function?  (bare supertype — issue #105)
+      //   - List<Function> / Map<String, Function?>  (issue #105)
       // And must NOT match:
       //   - A class named `MyFunction` (no `Function(` or `Function<`)
       //   - `Function` appearing in a doc comment (the type string is
@@ -304,6 +306,12 @@ void main() {
         'bool Function(Object)?': true,
         'T Function<U>(U)': true,
         'void Function(WebUri?, String)?': true,
+        // Issue #105 — bare `Function` forms (produced by the CLI when
+        // the user writes `--field "onLoad:!Function?"`):
+        'Function': true,
+        'Function?': true,
+        'List<Function>': true,
+        'Map<String, Function?>': true,
         // Negative cases — not function types:
         'String': false,
         'int?': false,
@@ -311,6 +319,7 @@ void main() {
         'Map<String, dynamic>': false,
         'MyFunctionClass': false,
         'FunctionRef': false,
+        'FunctionLikeBuilder': false,
       };
       // Access the private static method via reflection-ish trick:
       // invoke it through the public surface by emitting a class with


### PR DESCRIPTION
## Issue #105 — generator: value-object entities with callback fields (!Function?) emit @JsonSerializable with Function fields — json_serializable errors, .g.dart never generated (uncompilable output)

Closes #105.

### Repro

```bash
zfa entity create -n ScriptHtmlTagAttributes --kind=value_object \
  --field "type:String"  --field "id:String?" \
  --field "onLoad:!Function?"  --field "onError:!Function?"
zfa build
```

Before the fix: ZorphyGenerator emitted the @JsonSerializable concrete class with `final Function? onLoad;` / `final Function? onError;` fields, but no @JsonKey opt-out. json_serializable then failed with:

```
E json_serializable on .../script_html_tag_attributes.dart:
  Could not generate `fromJson` code for `onLoad`.
  .../script_html_tag_attributes.zorphy.dart:49:19
     ╷
  49 │   final Function? onLoad;
     │                   ^^^^^^
```

The .g.dart was NEVER written — the entity file references a missing `part '...g.dart'` → package does not compile.

### Root cause

The #89 fix in `ClassDeclarationGenerator._isFunctionType` only matched `Function(` and `Function<`. The BARE `Function` / `Function?` forms — produced by the CLI when the user writes a callback field without pinning down a signature (`--field "onLoad:!Function?"`) — slipped through. The CLI strips the `!` (external) marker and the trailing `?`, writes `Function? get onLoad;` to the entity file, and the analyzer resolves the field type to `Function?`. Without detection, the generator emitted `final Function? onLoad;` with no @JsonKey → json_serializable failed.

### Fix

Extend `_isFunctionType` with a word-boundary regex that matches the bare `Function` token (and its occurrences inside generic types like `List<Function>` / `Map<String, Function?>`) without false-positiving on class names like `MyFunction` / `FunctionRef` / `FunctionLikeBuilder`:

```dart
return RegExp(
  r'(?:^|[^A-Za-z0-9_])Function(?:$|[^A-Za-z0-9_])',
).hasMatch(cleaned);
```

The existing `_effectiveJsonKeyForField` pipeline then auto-emits `@JsonKey(includeFromJson: false, includeToJson: false)` on each bare-Function callback field, exactly as it does for the fully-typed `void Function(...)?` form from #89.

### Verification

- `dart analyze` on modified files → clean
- `dart test` (full suite) → 187 tests pass (13 of them in the new + extended regression tests)
- `dart run build_runner build` on the example fixture (mirrors the exact issue annotation shape) → .g.dart IS now generated (was NEVER generated before); `dart analyze` on the generated output → clean
- The generated `_$ScriptHtmlTagAttributesFromJson` and `_$ScriptHtmlTagAttributesToJson` correctly skip the `onLoad` / `onError` fields.

### Files

- `zorphy/lib/src/generators/class_declaration_generator.dart` — the fix (extended `_isFunctionType` + detailed `Issue #105` doc comment)
- `zorphy/test/generation/issue_89_function_typed_getter_test.dart` — added bare `Function` / `Function?` / `List<Function>` / `Map<String, Function?>` cases + `FunctionLikeBuilder` negative to the existing "various function-type shapes" test
- `zorphy/test/generation/issue_105_bare_function_field_test.dart` — NEW dedicated regression test (6 cases: exact issue repro, bare non-nullable `Function`, `Function` nested in generics, negative class-name-substring cases, mixed callback+data fields, user-provided @JsonKey augmentation)
- `zorphy/example/lib/various/issue_105_bare_function_field.dart` — NEW end-to-end example fixture using the exact issue annotation shape


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON generation for nullable, non-nullable, nested, and fully typed callback fields.
  - Preserved existing field declarations and custom serialization metadata.
  - Corrected migration handling for empty annotated constructors while retaining manual migration handling for constructors with logic or initializers.

- **Tests**
  - Added regression coverage for callback fields and constructor migration scenarios.
  - Expanded validation for similarly named non-function types.

- **Chores**
  - Streamlined generated test fixtures and release/deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->