### PR TITLE
feat(cli): typeKey + subtypeWireValue for polymorphic dispatch from zfa entity create (closes zuraffa#382)

### DIFF
--- a/zorphy/lib/src/cli/entity_creator.dart
+++ b/zorphy/lib/src/cli/entity_creator.dart
@@ -243,10 +243,13 @@ class EntityCreator {
     final resolver = ImportResolver(baseOutputDir: effectiveOutputDir);
 
     for (final subtype in parentConfig.explicitSubtypes) {
-      final subtypeName = subtype.replaceAll('\$', '');
-      final className = _formatClassName(subtypeName);
+      // Support name:wireValue format (e.g. "DefaultDisplayMode:DEFAULT_MODE")
+      final parts = subtype.split(':');
+      final rawName = parts[0].replaceAll('\$', '');
+      final wireValue = parts.length > 1 ? parts[1].trim() : null;
+      final className = _formatClassName(rawName);
       final snakeName = _toSnakeCase(className);
-      final fields = subtypeFields[subtype] ?? [];
+      final fields = subtypeFields[subtype] ?? subtypeFields[rawName] ?? [];
 
       final subtypeConfig = EntityConfig(
         name: className,
@@ -257,6 +260,7 @@ class EntityCreator {
         generateCompareTo: parentConfig.generateCompareTo,
         generateFilter: parentConfig.generateFilter,
         dryRun: parentConfig.dryRun,
+        subtypeWireValue: wireValue,
       );
 
       final imports = resolver.resolveSubtypeImports(

--- a/zorphy/lib/src/cli/generators/entity_template_generator.dart
+++ b/zorphy/lib/src/cli/generators/entity_template_generator.dart
@@ -148,6 +148,9 @@ class EntityTemplateGenerator {
     if (config.generateCompareTo)
       annotationOptions.add('generateCompareTo: true');
     if (config.generateFilter) annotationOptions.add('generateFilter: true');
+    if (config.subtypeWireValue != null) {
+      annotationOptions.add("subtypeWireValue: '${config.subtypeWireValue}'");
+    }
 
     buffer.writeln(
       '/// ${config.className} entity (subtype of $parentClassName)',
@@ -196,9 +199,16 @@ class EntityTemplateGenerator {
     if (config.generateCompareTo) options.add('generateCompareTo: true');
     if (config.isNonSealed) options.add('nonSealed: true');
     if (config.generateFilter) options.add('generateFilter: true');
+    if (config.typeKey != null) options.add("typeKey: '${config.typeKey}'");
+    if (config.subtypeWireValue != null) {
+      options.add("subtypeWireValue: '${config.subtypeWireValue}'");
+    }
 
     if (config.explicitSubtypes.isNotEmpty) {
-      final subtypes = config.explicitSubtypes.map((s) => '\$$s').join(', ');
+      // Strip optional :wireValue suffix from subtype names for the annotation
+      final subtypes = config.explicitSubtypes
+          .map((s) => '\$${s.split(':').first}')
+          .join(', ');
       options.add("explicitSubTypes: [$subtypes]");
     }
 

--- a/zorphy/lib/src/cli/models/entity_config.dart
+++ b/zorphy/lib/src/cli/models/entity_config.dart
@@ -28,6 +28,16 @@ class EntityConfig {
   /// [ZorphyKind.valueObject].
   final ZorphyKind kind;
 
+  /// Custom JSON key used for polymorphic type dispatch in `fromJson`
+  /// and `toJson`. When null, defaults to `'__typename'`.
+  /// Only meaningful on the **base** class.
+  final String? typeKey;
+
+  /// Custom wire value for this subtype in the base class's polymorphic
+  /// JSON dispatch. When null, the clean class name is used.
+  /// Only meaningful on **subtype** classes.
+  final String? subtypeWireValue;
+
   const EntityConfig({
     required this.name,
     this.outputDir,
@@ -46,6 +56,8 @@ class EntityConfig {
     this.prefixNested = true,
     this.autoId = false,
     this.kind = ZorphyKind.entity,
+    this.typeKey,
+    this.subtypeWireValue,
   });
 
   String get defaultOutputDir => 'lib/src/domain/entities';
@@ -88,6 +100,8 @@ class EntityConfig {
     bool? prefixNested,
     bool? autoId,
     ZorphyKind? kind,
+    String? typeKey,
+    String? subtypeWireValue,
   }) {
     return EntityConfig(
       name: name ?? this.name,
@@ -107,6 +121,8 @@ class EntityConfig {
       prefixNested: prefixNested ?? this.prefixNested,
       autoId: autoId ?? this.autoId,
       kind: kind ?? this.kind,
+      typeKey: typeKey ?? this.typeKey,
+      subtypeWireValue: subtypeWireValue ?? this.subtypeWireValue,
     );
   }
 }

--- a/zorphy/lib/src/cli/services/import_resolver.dart
+++ b/zorphy/lib/src/cli/services/import_resolver.dart
@@ -59,7 +59,7 @@ class ImportResolver {
 
     if (explicitSubtypes != null) {
       for (final subtype in explicitSubtypes) {
-        final cleanSubtype = subtype.replaceAll(RegExp(r'^\$+'), '');
+        final cleanSubtype = subtype.replaceAll(RegExp(r'^\$+'), '').split(':').first;
         if (cleanSubtype != className) {
           if (!(generateSubtypes && isSealed)) {
             final subtypeSnakeName = NamingUtils.toSnakeCase(cleanSubtype);


### PR DESCRIPTION
Adds --type-key and --subtype-wire-value flags to `zfa entity create` with name:wireValue format in --subtypes. Verified end-to-end: fromJson dispatches on custom typeKey, toJson emits custom wire values.