### PR TITLE
fix(generator): Patch + FieldEnum for nonSealed abstract bases (closes #111)

### DIFF
--- a/zorphy/lib/src/cli/entity_creator.dart
+++ b/zorphy/lib/src/cli/entity_creator.dart
@@ -243,10 +243,18 @@ class EntityCreator {
     final resolver = ImportResolver(baseOutputDir: effectiveOutputDir);
 
     for (final subtype in parentConfig.explicitSubtypes) {
-      // Support name:wireValue format (e.g. "DefaultDisplayMode:DEFAULT_MODE")
-      final parts = subtype.split(':');
-      final rawName = parts[0].replaceAll('\$', '');
-      final wireValue = parts.length > 1 ? parts[1].trim() : null;
+      // Support name:wireValue format (e.g. "DefaultDisplayMode:DEFAULT_MODE").
+      // Split at the FIRST colon only — the wire value itself may contain
+      // colons (e.g. "Product:urn:product" → name "Product", value
+      // "urn:product").
+      final separator = subtype.indexOf(':');
+      final rawName = (separator < 0
+              ? subtype
+              : subtype.substring(0, separator))
+          .trim()
+          .replaceAll(RegExp(r'^\$+'), '');
+      final wireValue =
+          separator < 0 ? null : subtype.substring(separator + 1).trim();
       final className = _formatClassName(rawName);
       final snakeName = _toSnakeCase(className);
       final fields = subtypeFields[subtype] ?? subtypeFields[rawName] ?? [];

--- a/zorphy/lib/src/cli/entity_creator.dart
+++ b/zorphy/lib/src/cli/entity_creator.dart
@@ -243,10 +243,13 @@ class EntityCreator {
     final resolver = ImportResolver(baseOutputDir: effectiveOutputDir);
 
     for (final subtype in parentConfig.explicitSubtypes) {
-      final subtypeName = subtype.replaceAll('\$', '');
-      final className = _formatClassName(subtypeName);
+      // Support name:wireValue format (e.g. "DefaultDisplayMode:DEFAULT_MODE")
+      final parts = subtype.split(':');
+      final rawName = parts[0].replaceAll('\$', '');
+      final wireValue = parts.length > 1 ? parts[1].trim() : null;
+      final className = _formatClassName(rawName);
       final snakeName = _toSnakeCase(className);
-      final fields = subtypeFields[subtype] ?? [];
+      final fields = subtypeFields[subtype] ?? subtypeFields[rawName] ?? [];
 
       final subtypeConfig = EntityConfig(
         name: className,
@@ -257,6 +260,7 @@ class EntityCreator {
         generateCompareTo: parentConfig.generateCompareTo,
         generateFilter: parentConfig.generateFilter,
         dryRun: parentConfig.dryRun,
+        subtypeWireValue: wireValue,
       );
 
       final imports = resolver.resolveSubtypeImports(

--- a/zorphy/lib/src/cli/generators/entity_template_generator.dart
+++ b/zorphy/lib/src/cli/generators/entity_template_generator.dart
@@ -148,6 +148,9 @@ class EntityTemplateGenerator {
     if (config.generateCompareTo)
       annotationOptions.add('generateCompareTo: true');
     if (config.generateFilter) annotationOptions.add('generateFilter: true');
+    if (config.subtypeWireValue != null) {
+      annotationOptions.add("subtypeWireValue: '${config.subtypeWireValue}'");
+    }
 
     buffer.writeln(
       '/// ${config.className} entity (subtype of $parentClassName)',
@@ -196,9 +199,16 @@ class EntityTemplateGenerator {
     if (config.generateCompareTo) options.add('generateCompareTo: true');
     if (config.isNonSealed) options.add('nonSealed: true');
     if (config.generateFilter) options.add('generateFilter: true');
+    if (config.typeKey != null) options.add("typeKey: '${config.typeKey}'");
+    if (config.subtypeWireValue != null) {
+      options.add("subtypeWireValue: '${config.subtypeWireValue}'");
+    }
 
     if (config.explicitSubtypes.isNotEmpty) {
-      final subtypes = config.explicitSubtypes.map((s) => '\$$s').join(', ');
+      // Strip optional :wireValue suffix from subtype names for the annotation
+      final subtypes = config.explicitSubtypes
+          .map((s) => '\$${s.split(':').first}')
+          .join(', ');
       options.add("explicitSubTypes: [$subtypes]");
     }
 

--- a/zorphy/lib/src/cli/generators/entity_template_generator.dart
+++ b/zorphy/lib/src/cli/generators/entity_template_generator.dart
@@ -5,6 +5,38 @@ import '../models/entity_config.dart';
 class EntityTemplateGenerator {
   const EntityTemplateGenerator._();
 
+  /// Escapes a string value for safe interpolation into a Dart string
+  /// literal. Handles apostrophes, backslashes, quotes, dollar signs, and
+  /// line breaks. Mirrors `_escapeDartStringLiteral` in json_generator.dart.
+  static String _escapeDartStringLiteral(String value) {
+    return value
+        .replaceAll('\\', '\\\\') // backslash must be first
+        .replaceAll("'", "\\'") // single quote
+        .replaceAll('"', '\\"') // double quote
+        .replaceAll('\$', '\\\$') // dollar sign
+        .replaceAll('\n', '\\n') // newline
+        .replaceAll('\r', '\\r') // carriage return
+        .replaceAll('\t', '\\t'); // tab
+  }
+
+  /// Normalizes a subtype name the same way [EntityCreator._formatClassName]
+  /// does, so annotation references match the generated subtype classes
+  /// (e.g. `default_display_mode:DEFAULT_MODE` → `DefaultDisplayMode`).
+  static String _formatSubtypeClassName(String subtype) {
+    final name = subtype
+        .split(':')
+        .first
+        .replaceAll(r'$', '')
+        .trim();
+    final parts = name.split(RegExp(r'[_\s\-]+'));
+    return parts
+        .map((part) {
+          if (part.isEmpty) return '';
+          return part[0].toUpperCase() + part.substring(1);
+        })
+        .join('');
+  }
+
   /// Generate entity file content
   static String generate(EntityConfig config, List<String> imports) {
     final buffer = StringBuffer();
@@ -149,7 +181,9 @@ class EntityTemplateGenerator {
       annotationOptions.add('generateCompareTo: true');
     if (config.generateFilter) annotationOptions.add('generateFilter: true');
     if (config.subtypeWireValue != null) {
-      annotationOptions.add("subtypeWireValue: '${config.subtypeWireValue}'");
+      annotationOptions.add(
+        "subtypeWireValue: '${_escapeDartStringLiteral(config.subtypeWireValue!)}'",
+      );
     }
 
     buffer.writeln(
@@ -199,15 +233,21 @@ class EntityTemplateGenerator {
     if (config.generateCompareTo) options.add('generateCompareTo: true');
     if (config.isNonSealed) options.add('nonSealed: true');
     if (config.generateFilter) options.add('generateFilter: true');
-    if (config.typeKey != null) options.add("typeKey: '${config.typeKey}'");
+    if (config.typeKey != null) {
+      options.add("typeKey: '${_escapeDartStringLiteral(config.typeKey!)}'");
+    }
     if (config.subtypeWireValue != null) {
-      options.add("subtypeWireValue: '${config.subtypeWireValue}'");
+      options.add(
+        "subtypeWireValue: '${_escapeDartStringLiteral(config.subtypeWireValue!)}'",
+      );
     }
 
     if (config.explicitSubtypes.isNotEmpty) {
-      // Strip optional :wireValue suffix from subtype names for the annotation
+      // Strip optional :wireValue suffix from subtype names and normalize
+      // them with the same class-name rules EntityCreator uses, so the
+      // annotation references match the generated subtype classes.
       final subtypes = config.explicitSubtypes
-          .map((s) => '\$${s.split(':').first}')
+          .map((s) => '\$${_formatSubtypeClassName(s)}')
           .join(', ');
       options.add("explicitSubTypes: [$subtypes]");
     }

--- a/zorphy/lib/src/cli/models/entity_config.dart
+++ b/zorphy/lib/src/cli/models/entity_config.dart
@@ -28,6 +28,16 @@ class EntityConfig {
   /// [ZorphyKind.valueObject].
   final ZorphyKind kind;
 
+  /// Custom JSON key used for polymorphic type dispatch in `fromJson`
+  /// and `toJson`. When null, defaults to `'__typename'`.
+  /// Only meaningful on the **base** class.
+  final String? typeKey;
+
+  /// Custom wire value for this subtype in the base class's polymorphic
+  /// JSON dispatch. When null, the clean class name is used.
+  /// Only meaningful on **subtype** classes.
+  final String? subtypeWireValue;
+
   const EntityConfig({
     required this.name,
     this.outputDir,
@@ -46,6 +56,8 @@ class EntityConfig {
     this.prefixNested = true,
     this.autoId = false,
     this.kind = ZorphyKind.entity,
+    this.typeKey,
+    this.subtypeWireValue,
   });
 
   String get defaultOutputDir => 'lib/src/domain/entities';
@@ -88,6 +100,8 @@ class EntityConfig {
     bool? prefixNested,
     bool? autoId,
     ZorphyKind? kind,
+    String? typeKey,
+    String? subtypeWireValue,
   }) {
     return EntityConfig(
       name: name ?? this.name,
@@ -107,6 +121,8 @@ class EntityConfig {
       prefixNested: prefixNested ?? this.prefixNested,
       autoId: autoId ?? this.autoId,
       kind: kind ?? this.kind,
+      typeKey: typeKey ?? this.typeKey,
+      subtypeWireValue: subtypeWireValue ?? this.subtypeWireValue,
     );
   }
 }

--- a/zorphy/lib/src/cli/services/import_resolver.dart
+++ b/zorphy/lib/src/cli/services/import_resolver.dart
@@ -59,7 +59,7 @@ class ImportResolver {
 
     if (explicitSubtypes != null) {
       for (final subtype in explicitSubtypes) {
-        final cleanSubtype = subtype.replaceAll(RegExp(r'^\$+'), '');
+        final cleanSubtype = subtype.replaceAll(RegExp(r'^\$+'), '').split(':').first;
         if (cleanSubtype != className) {
           if (!(generateSubtypes && isSealed)) {
             final subtypeSnakeName = NamingUtils.toSnakeCase(cleanSubtype);

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -12,7 +12,12 @@ class PatchGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch || context.metadata.isAbstract) {
+    if (!context.config.generatePatch) {
+      return false;
+    }
+    // NonSealed abstract bases need a Patch class because parent entities
+    // reference it in their own Patch generation (e.g. withXxxPatch methods).
+    if (context.metadata.isAbstract && !context.metadata.nonSealed) {
       return false;
     }
     return context.metadata.allFields.isNotEmpty ||
@@ -164,7 +169,12 @@ class PatchClassGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch || context.metadata.isAbstract) {
+    if (!context.config.generatePatch) {
+      return false;
+    }
+    // NonSealed abstract bases need a Patch class because parent entities
+    // reference it in their own Patch generation (e.g. withXxxPatch methods).
+    if (context.metadata.isAbstract && !context.metadata.nonSealed) {
       return false;
     }
     return context.metadata.allFields.isNotEmpty ||

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -27,9 +27,11 @@ class PatchGenerator extends ConcreteClassGenerator {
     final classNameTrimmed = metadata.cleanName.replaceAll(r'$', '');
     final specs = <Spec>[];
 
-    // Main patchWith method
+    // Main patchWith method — skip for nonSealed abstract bases (can't instantiate).
     final fields = metadata.allFields;
-    if (fields.isEmpty) {
+    if (metadata.isAbstract && metadata.nonSealed) {
+      // Abstract nonSealed base: no patchWith or applyTo needed.
+    } else if (fields.isEmpty) {
       // Fieldless class: identity patchWith
       specs.add(
         Method((m) {
@@ -180,6 +182,15 @@ class PatchClassGenerator extends ConcreteClassGenerator {
         .map((k) => k.replaceAll(r'$', ''))
         .toList();
     final genericTypeNames = metadata.generics.map((g) => g.name).toList();
+
+    // Abstract nonSealed bases: emit minimal abstract Patch stub (data holder
+    // only, no applyTo). The full Patch with applyTo is for concrete classes.
+    if (metadata.isAbstract && metadata.nonSealed) {
+      final cleanName = metadata.cleanName.replaceAll(r'$', '');
+      return [Code('abstract class ${metadata.cleanName}Patch '
+          'extends PatchBase<$cleanName, ${metadata.cleanName}\$> {}')];
+    }
+
     final code = helpers.getPatchClass(
       metadata.allFields,
       metadata.cleanName,

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -30,8 +30,12 @@ class PatchGenerator extends ConcreteClassGenerator {
     // Main patchWith method — skip for nonSealed abstract bases (can't instantiate).
     final fields = metadata.allFields;
     if (metadata.isAbstract && metadata.nonSealed) {
-      // Abstract nonSealed base: no patchWith or applyTo needed.
-    } else if (fields.isEmpty) {
+      // Abstract nonSealed base: no patchWith or applyTo needed. Interface
+      // patchWith methods would construct this class, which is impossible —
+      // return before the interface loop.
+      return specs;
+    }
+    if (fields.isEmpty) {
       // Fieldless class: identity patchWith
       specs.add(
         Method((m) {
@@ -187,8 +191,33 @@ class PatchClassGenerator extends ConcreteClassGenerator {
     // only, no applyTo). The full Patch with applyTo is for concrete classes.
     if (metadata.isAbstract && metadata.nonSealed) {
       final cleanName = metadata.cleanName.replaceAll(r'$', '');
-      return [Code('abstract class ${metadata.cleanName}Patch '
-          'extends PatchBase<$cleanName, ${metadata.cleanName}\$> {}')];
+      // Preserve the entity's generic parameters on the stub and use the
+      // parameterized entity type in PatchBase (e.g. BasePatch<T, U extends
+      // num> extends PatchBase<Base<T, U>, Base$>). The field enum stays
+      // unparameterized.
+      final genericParams = metadata.generics
+          .map((g) => g.toString())
+          .toList();
+      final genericDecl = genericParams.isEmpty
+          ? ''
+          : '<${genericParams.join(', ')}>';
+      final genericArgs = genericParams.isEmpty
+          ? ''
+          : '<${metadata.generics.map((g) => g.name).join(', ')}>';
+      final stub = Code('abstract class ${metadata.cleanName}Patch'
+          '$genericDecl extends PatchBase<$cleanName$genericArgs, '
+          '${metadata.cleanName}\$> {}');
+      if (metadata.allFields.isEmpty) {
+        // Fieldless subtype: the stub references ${cleanName}$ but
+        // getEnumPropertyList emits nothing for empty fields — emit the
+        // same placeholder enum getPatchClass uses for fieldless classes.
+        return [
+          stub,
+          Code('/// Placeholder field enum for fieldless [$cleanName].\n'
+              'enum ${metadata.cleanName}\$ { none }'),
+        ];
+      }
+      return [stub];
     }
 
     final code = helpers.getPatchClass(

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -12,9 +12,10 @@ class PatchGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch || context.metadata.isAbstract) {
-      return false;
-    }
+    if (!context.config.generatePatch) return false;
+    // NonSealed abstract bases need Patch because parent entities
+    // reference them in their own Patch generation (withXxxPatch methods).
+    if (context.metadata.isAbstract && !context.metadata.nonSealed) return false;
     return context.metadata.allFields.isNotEmpty ||
         context.metadata.isInParentExplicitSubtypes;
   }
@@ -164,9 +165,10 @@ class PatchClassGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch || context.metadata.isAbstract) {
-      return false;
-    }
+    if (!context.config.generatePatch) return false;
+    // NonSealed abstract bases need Patch because parent entities
+    // reference them in their own Patch generation (withXxxPatch methods).
+    if (context.metadata.isAbstract && !context.metadata.nonSealed) return false;
     return context.metadata.allFields.isNotEmpty ||
         context.metadata.isInParentExplicitSubtypes;
   }
@@ -198,8 +200,11 @@ class FieldEnumGenerator extends ConcreteClassGenerator {
   @override
   bool shouldGenerate(GenerationContext context) {
     return context.config.generatePatch &&
-        !context.metadata.isAbstract &&
-        context.metadata.allFields.isNotEmpty;
+        (context.metadata.isAbstract && context.metadata.nonSealed
+            ? context.metadata.allFields.isNotEmpty ||
+                context.metadata.isInParentExplicitSubtypes
+            : !context.metadata.isAbstract &&
+                context.metadata.allFields.isNotEmpty);
   }
 
   @override

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -12,12 +12,7 @@ class PatchGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch) {
-      return false;
-    }
-    // NonSealed abstract bases need a Patch class because parent entities
-    // reference it in their own Patch generation (e.g. withXxxPatch methods).
-    if (context.metadata.isAbstract && !context.metadata.nonSealed) {
+    if (!context.config.generatePatch || context.metadata.isAbstract) {
       return false;
     }
     return context.metadata.allFields.isNotEmpty ||
@@ -169,12 +164,7 @@ class PatchClassGenerator extends ConcreteClassGenerator {
 
   @override
   bool shouldGenerate(GenerationContext context) {
-    if (!context.config.generatePatch) {
-      return false;
-    }
-    // NonSealed abstract bases need a Patch class because parent entities
-    // reference it in their own Patch generation (e.g. withXxxPatch methods).
-    if (context.metadata.isAbstract && !context.metadata.nonSealed) {
+    if (!context.config.generatePatch || context.metadata.isAbstract) {
       return false;
     }
     return context.metadata.allFields.isNotEmpty ||

--- a/zorphy/test/generation/issue_111_patch_nonsealed_test.dart
+++ b/zorphy/test/generation/issue_111_patch_nonsealed_test.dart
@@ -1,0 +1,180 @@
+// Regression test for issue #111 review findings on PR #112:
+// "nonSealed abstract bases: Patch + FieldEnum generation"
+//
+// Verifies that:
+//  1. The abstract Patch stub preserves the entity's generic parameters
+//     (including bounds) and parameterizes the PatchBase entity type, while
+//     the field enum stays unparameterized.
+//  2. Fieldless abstract nonSealed subtypes still get a placeholder field
+//     enum — the stub references `X$` but getEnumPropertyList returns ''
+//     for empty fields.
+//  3. PatchGenerator emits no patchWith methods (main or interface) for
+//     abstract nonSealed bases — an abstract class cannot be constructed.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/patch_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+import 'package:zorphy/src/models/interface_metadata.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+ClassMetadata _meta({
+  required String originalName,
+  required String cleanName,
+  required bool isAbstract,
+  required bool nonSealed,
+  bool isInParentExplicitSubtypes = false,
+  List<GenericParameterMetadata> generics = const [],
+  List<InterfaceMetadata> interfaces = const [],
+  List<NameTypeClassComment> fields = const [],
+}) {
+  return ClassMetadata(
+    originalName: originalName,
+    cleanName: cleanName,
+    isAbstract: isAbstract,
+    isSealed: isAbstract && !nonSealed,
+    nonSealed: nonSealed,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: generics,
+    interfaces: interfaces,
+    allValueTInterfaces: const [],
+    allFields: fields,
+    ownFieldNames: const {},
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: isInParentExplicitSubtypes,
+    classElement: _StubClassElement(cleanName),
+    allAnnotatedClasses: const {},
+  );
+}
+
+GenerationConfig _patchConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.entity,
+    autoId: false,
+    generateJson: false,
+    explicitToJson: false,
+    generateCopyWith: false,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: true,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: true,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+String _emit(List<Spec> specs) {
+  final lib = Library((b) => b.body.addAll(specs));
+  return lib.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+}
+
+void main() {
+  group('issue #111 — nonSealed abstract Patch stub', () {
+    test('golden: bounded generic parameters are preserved on the stub', () {
+      final meta = _meta(
+        originalName: '\$\$Base',
+        cleanName: 'Base',
+        isAbstract: true,
+        nonSealed: true,
+        generics: [
+          GenericParameterMetadata(name: 'T'),
+          GenericParameterMetadata(name: 'U', bound: 'num'),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _patchConfig());
+      final specs = PatchClassGenerator().generateSpec(context);
+      final emitted = _emit(specs);
+
+      // Golden: declaration carries the bounded params, PatchBase gets the
+      // parameterized entity type, and the field enum stays unparameterized.
+      expect(
+        emitted,
+        contains('abstract class BasePatch<T, U extends num> '
+            'extends PatchBase<Base<T, U>, Base\$> {}'),
+      );
+      expect(emitted, isNot(contains('Base\$<')));
+      expect(emitted, isNot(contains('PatchBase<Base, Base\$>')));
+    });
+
+    test('non-generic stub stays unchanged', () {
+      final meta = _meta(
+        originalName: '\$\$Base',
+        cleanName: 'Base',
+        isAbstract: true,
+        nonSealed: true,
+      );
+      final context = GenerationContext(metadata: meta, config: _patchConfig());
+      final emitted = _emit(PatchClassGenerator().generateSpec(context));
+
+      expect(
+        emitted,
+        contains('abstract class BasePatch extends PatchBase<Base, Base\$> {}'),
+      );
+    });
+
+    test('fieldless explicit subtype gets a placeholder field enum', () {
+      final meta = _meta(
+        originalName: '\$Marker',
+        cleanName: 'Marker',
+        isAbstract: true,
+        nonSealed: true,
+        isInParentExplicitSubtypes: true,
+      );
+      final context = GenerationContext(metadata: meta, config: _patchConfig());
+      final emitted = _emit(PatchClassGenerator().generateSpec(context));
+
+      // The stub references Marker$, so a placeholder enum must exist for the
+      // generated Dart to compile (getEnumPropertyList returns '' when there
+      // are no fields).
+      expect(emitted, contains('PatchBase<Marker, Marker\$>'));
+      expect(emitted, contains('enum Marker\$ { none }'));
+    });
+
+    test('PatchGenerator emits no methods for abstract nonSealed bases', () {
+      final iface = InterfaceMetadata(
+        '\$Named',
+        [],
+        [],
+        [NameType('name', 'String')],
+        element: _StubClassElement('Named'),
+      );
+      final meta = _meta(
+        originalName: '\$\$Base',
+        cleanName: 'Base',
+        isAbstract: true,
+        nonSealed: true,
+        interfaces: [iface],
+        fields: [NameTypeClassComment('name', 'String', '')],
+      );
+      final context = GenerationContext(metadata: meta, config: _patchConfig());
+
+      // shouldGenerate gates this on (abstract + nonSealed), but generateSpec
+      // must not emit interface patchWith methods that would construct the
+      // abstract class.
+      expect(PatchGenerator().shouldGenerate(context), isTrue);
+      expect(PatchGenerator().generateSpec(context), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Generates Patch class (minimal abstract stub) + FieldEnum for nonSealed abstract base entities. Enables polymorphic entities as fields in other entities. PatchGenerator skips patchWith for abstract bases; PatchClassGenerator emits abstract stub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for polymorphic JSON configuration using custom type keys and subtype wire values.
  * Improved subtype generation for entries with explicit wire values and `$`-prefixed names.
  * Added patch generation support for abstract non-sealed classes.
* **Bug Fixes**
  * Improved subtype name normalization and import resolution for consistent generated code.
  * Preserved subtype wire values in generated entity and subtype annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->