### PR TITLE
fix(generators): generated code analyzes pristine — typed patchWith casts + typed toJsonLean

### DIFF
--- a/zorphy/lib/src/generators/json_generator.dart
+++ b/zorphy/lib/src/generators/json_generator.dart
@@ -302,7 +302,8 @@ class JsonGenerator extends UniversalGenerator {
         body.add(
             "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
       }
-      body.add('return _sanitizeJson(data);');
+      body.add('_sanitizeJson(data);');
+      body.add('return data;');
       specs.add(Method((m) {
         m.name = 'toJsonLean';
         m.returns = referType('Map<String, dynamic>');
@@ -321,7 +322,8 @@ class JsonGenerator extends UniversalGenerator {
         body.add(
             "if (${f.name} != null) data['$jsonFieldName'] = ${info.toJson}(${f.name}!);");
       }
-      body.add('return _sanitizeJson(data);');
+      body.add('_sanitizeJson(data);');
+      body.add('return data;');
       specs.add(Method((m) {
         m.name = 'toJsonLean';
         m.returns = referType('Map<String, dynamic>');

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -94,7 +94,7 @@ class PatchGenerator extends ConcreteClassGenerator {
         final comma = i == fields.length - 1 ? '' : ',';
         if (interfaceFieldNames.contains(f.name)) {
           bodyLines.add(
-            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (${f.type})( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) : this.${f.name}$comma",
+            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
           );
         } else {
           bodyLines.add('${f.name}: this.${f.name},');
@@ -138,7 +138,7 @@ class PatchGenerator extends ConcreteClassGenerator {
       final f = fields[i];
       final comma = i == fields.length - 1 ? '' : ',';
       bodyLines.add(
-        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (${f.type})( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) : this.${f.name}$comma",
+        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
       );
     }
 

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -89,10 +89,12 @@ class PatchGenerator extends ConcreteClassGenerator {
       final constructorSuffix = config.hidePublicConstructor ? '._' : '';
       bodyLines.add('return $classNameTrimmed$constructorSuffix(');
 
-      for (final f in fields) {
+      for (var i = 0; i < fields.length; i++) {
+        final f = fields[i];
+        final comma = i == fields.length - 1 ? '' : ',';
         if (interfaceFieldNames.contains(f.name)) {
           bodyLines.add(
-            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] : this.${f.name},",
+            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (${f.type})( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) : this.${f.name}$comma",
           );
         } else {
           bodyLines.add('${f.name}: this.${f.name},');
@@ -136,7 +138,7 @@ class PatchGenerator extends ConcreteClassGenerator {
       final f = fields[i];
       final comma = i == fields.length - 1 ? '' : ',';
       bodyLines.add(
-        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] : this.${f.name}$comma",
+        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? (${f.type})( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) : this.${f.name}$comma",
       );
     }
 


### PR DESCRIPTION
## Summary
- **patchWith**: the generated ternary chains over `_patchMap` collapse to `dynamic` (map lookups + dynamic invokes), so generated constructors received `dynamic` arguments for typed parameters — `argument_type_not_assignable` on every patched field (~String/DateTime/int/…). Fix: wrap the whole patched-value expression in an explicit field-type cast `(String)( … )`.
- **toJsonLean**: returned `_sanitizeJson(data)` whose return type is `dynamic` → `return_of_invalid_type` against `Map<String, dynamic>`. Fix: sanitize in place (`_sanitizeJson(data);`) and `return data;`.

## Reproduction
Battle-tested by the zuraffa_agent zfa-only pipeline (misfire #002): `zfa entity create` × 12 entities → `zfa build` → `dart analyze` = **189 issues, ~60 inside generated `.zorphy.dart`** — hard compile errors like:
```
error - artifact_ref.zorphy.dart:44:13 - The argument type 'dynamic' can't be assigned to the parameter type 'String'.
error - artifact_ref.zorphy.dart:94:12 - A value of type 'dynamic' can't be returned from 'toJsonLean'.
```

## Verification
- zorphy: `dart test` = **181/181 pass**
- zuraffa_agent: after this fix, regenerated entities analyze clean inside generated files (postmortem: zuraffa_agent@c2bc4cd; Article X of its constitution v1.2.0 now requires pristine analyze after every zfa build).

## Context
Found during the first fully automated zfa-CLI-only spec run (zuraffa_agent spec 001). Postmortem cross-ref: `arrrrny/zuraffa_agent` commit `c2bc4cd`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated JSON conversion to ensure sanitization is applied consistently while preserving the expected output map.
  - Fixed generated patch updates so field values are correctly converted to their declared types before assignment.
  - Corrected formatting of generated interface patches, including comma placement for the final field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->