### PR TITLE
fix(cli): resolve sibling-entity imports for external (!Type) fields — cross-entity references

### DIFF
--- a/zorphy/lib/src/cli/services/import_resolver.dart
+++ b/zorphy/lib/src/cli/services/import_resolver.dart
@@ -22,9 +22,12 @@ class ImportResolver {
     bool needsEnumImport = false;
 
     for (final field in fields) {
-      // External types (`!Type` marker) are imported by the user — no
-      // entity/enum import can or should be resolved for them.
-      if (field.isExternal) continue;
+      // External types (`!Type` marker): the import is normally provided by
+      // the user. BUT if the referenced type is a sibling Zorphy entity on
+      // disk, resolve the relative import automatically — otherwise the
+      // generated file references an unresolved identifier (analyzer error,
+      // json_serializable InvalidType). Cross-entity references are the
+      // primary use of `!Type`, and the sibling almost always exists.
       final typeRefs = NamingUtils.extractTypeReferences(field.type);
 
       for (final typeRef in typeRefs) {
@@ -36,10 +39,15 @@ class ImportResolver {
         final typeSnakeName = NamingUtils.toSnakeCase(cleanTypeRef);
         final potentialEntityPath = p.join(baseOutputDir, typeSnakeName);
 
-        if (typeRef.startsWith(r'$') ||
-            Directory(potentialEntityPath).existsSync()) {
+        if (!field.isExternal &&
+            (typeRef.startsWith(r'$') ||
+                Directory(potentialEntityPath).existsSync())) {
           imports.add("import '../$typeSnakeName/$typeSnakeName.dart';");
-        } else {
+        } else if (field.isExternal &&
+            Directory(potentialEntityPath).existsSync()) {
+          // External type that IS a local sibling entity: import it.
+          imports.add("import '../$typeSnakeName/$typeSnakeName.dart';");
+        } else if (!field.isExternal) {
           needsEnumImport = true;
         }
       }
@@ -84,9 +92,8 @@ class ImportResolver {
     bool needsEnumImport = false;
 
     for (final field in fields) {
-      // External types (`!Type` marker) are imported by the user — no
-      // entity/enum import can or should be resolved for them.
-      if (field.isExternal) continue;
+      // External types: import sibling entities on disk (cross-entity refs);
+      // truly external types remain user-imported.
       final typeRefs = NamingUtils.extractTypeReferences(field.type);
 
       for (final typeRef in typeRefs) {
@@ -98,10 +105,15 @@ class ImportResolver {
         final typeSnakeName = NamingUtils.toSnakeCase(cleanTypeRef);
         final potentialEntityPath = p.join(baseOutputDir, typeSnakeName);
 
-        if (typeRef.startsWith(r'\$') ||
-            Directory(potentialEntityPath).existsSync()) {
+        if (!field.isExternal &&
+            (typeRef.startsWith(r'\$') ||
+                Directory(potentialEntityPath).existsSync())) {
           imports.add("import '../$typeSnakeName/$typeSnakeName.dart';");
-        } else {
+        } else if (field.isExternal &&
+            Directory(potentialEntityPath).existsSync()) {
+          // External type that IS a local sibling entity: import it.
+          imports.add("import '../$typeSnakeName/$typeSnakeName.dart';");
+        } else if (!field.isExternal) {
           needsEnumImport = true;
         }
       }


### PR DESCRIPTION
## Summary
`zfa entity create --field x:'!Sibling'` (external type marker) generated the field type correctly but emitted **no import** for it: `ImportResolver.resolveImports` skipped external fields entirely. When the referenced type is a sibling Zorphy entity (the primary cross-entity-reference use case), the generated file references an unresolved identifier → analyzer error + `json_serializable` fails with `InvalidType` (cannot generate fromJson/toJson).

## Fix
For external fields, check whether the referenced type exists as a sibling entity directory under `baseOutputDir`; if yes, emit the relative import `../<snake>/<snake>.dart`. Truly external types (not on disk) remain user-imported, unchanged. Applied to both `resolveImports` and `resolveSubtypeImports`.

## Reproduction (from zuraffa_agent spec-002 pipeline, misfire #003)
```bash
zfa entity create -n StopPolicy --field maxTurns:int --field wallClockTimeout:'!Duration' --field repetitionThreshold:int --field enabled:bool
zfa entity create -n EngineLoop --field loopId:String --field stopPolicy:'!StopPolicy' --field steeringQueue:'List<String>'
zfa build --force
# → E json_serializable: Could not generate `fromJson` for `stopPolicy` (InvalidType)
```
After fix: sibling import emitted; EngineLoop.zorphy.dart references a resolved type; json_serializable generates fromJson/toJson normally.

## Verification
- zorphy: `dart test` **181/181 pass**, generator analyze clean
- zuraffa_agent: regenerated entity tree builds (spec-002 battle test)

## Context
Postmortem: zuraffa_agent `.workflow/state/002-engine-core-loop/misfire.md`. Constitution III escalation from the zfa-only pipeline battle test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import resolution for locally defined sibling entities, including fields using external-type markers.
  * Prevented unresolved genuinely external types from being incorrectly treated as local imports.
  * Corrected enum import handling so enums are imported only when appropriate.
  * Preserved support for existing local entities and explicitly referenced imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->