### PR TITLE
fix: strip leading `$` from patchWith/fromJson cast type for explicit-subtype fields

### DIFF
--- a/zorphy/lib/src/generators/json_generator.dart
+++ b/zorphy/lib/src/generators/json_generator.dart
@@ -85,7 +85,7 @@ class JsonGenerator extends UniversalGenerator {
             final info = manualField.first.jsonKeyInfo!;
             final jsonFieldName = info.name ?? f.name;
             bodyLines.add(
-                "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
+                "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type!.replaceAll(r'$', '')} : null,");
           } else {
             bodyLines.add('      ${f.name}: instance.${f.name},');
           }
@@ -244,7 +244,7 @@ class JsonGenerator extends UniversalGenerator {
           final info = manualField.first.jsonKeyInfo!;
           final jsonFieldName = info.name ?? f.name;
           bodyLines.add(
-              "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
+              "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type!.replaceAll(r'$', '')} : null,");
         } else {
           bodyLines.add('      ${f.name}: instance.${f.name},');
         }

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -94,7 +94,7 @@ class PatchGenerator extends ConcreteClassGenerator {
         final comma = i == fields.length - 1 ? '' : ',';
         if (interfaceFieldNames.contains(f.name)) {
           bodyLines.add(
-            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
+            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type!.replaceAll(r'$', '')} : this.${f.name}$comma",
           );
         } else {
           bodyLines.add('${f.name}: this.${f.name},');
@@ -138,7 +138,7 @@ class PatchGenerator extends ConcreteClassGenerator {
       final f = fields[i];
       final comma = i == fields.length - 1 ? '' : ',';
       bodyLines.add(
-        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
+        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type!.replaceAll(r'$', '')} : this.${f.name}$comma",
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes a code-generation bug where `patchWith` (and manual-fromJson) casts used the raw, `$`-prefixed explicit-subtype type name, producing an undefined-identifier compile error in generated code.

## Root cause

`patch_generator.dart` and `json_generator.dart` emit `as ${f.type}` for the `patchWith` ternary cast. For a field whose type is an explicit-subtype class (declared with a leading `$`, e.g. `abstract class $Credentials`), `f.type` carries that `$` prefix, so the generator emitted `as $Credentials?`. In the consuming file the field is declared with the trimmed name (`Credentials?`), so `$Credentials` is undefined and compilation fails.

This is the root cause behind arrrrny/zuraffa#401 (and arrrrny/zuraffa's failing tests); filed as arrrrny/zorphy#119.

## Fix

Strip the leading `$` from the cast type in both generators:

- `patch_generator.dart` (`_buildPatchWithMethod` + interface variant): `as ${f.type!.replaceAll(r'$', '')}`
- `json_generator.dart` (manual-fromJson branches): `as ${f.type!.replaceAll(r'$', '')}`

`helpers.dart` already strips `$` for list/map element casts, so this makes the cast handling consistent.

## Verification

Regenerating zuraffa with this fix removes the `$`-prefixed casts; `as Credentials?` / `as Settings?` are emitted instead and all Flutter tests pass. `dart analyze` on the two changed files is clean.

Fixes arrrrny/zorphy#119.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated JSON deserialization casts for fields with marked type names.
  * Fixed generated patch operations to correctly recognize field types, improving type-safe updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->