### PR TITLE
fix(zorphy)+test: subtype patchWith cast strips leading $ (guards #119)

### DIFF
--- a/zorphy/CHANGELOG.md
+++ b/zorphy/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [Unreleased]
+
+### Fix
+
+- Generators: cross-entity `patchWith` cast now uses the concrete entity
+  type — when a Zorphy entity declared a field whose type was the ABSTRACT
+  form of another Zorphy entity (e.g. `$ArtifactRef get ref;` — the canonical
+  CLI-generated shape, since `FieldNormalizer` prepends the `$` prefix to
+  entity references), the generated `patchWith` body emitted a cast against
+  the ABSTRACT form (`as $ArtifactRef`), which is the supertype of the field's
+  declared CONCRETE form (`ArtifactRef`). The analyzer rejected this as
+  `argument_type_not_assignable` (reported as `Object` because the concrete
+  type was unresolved during build_runner analysis — issue #351 background).
+  The cast target is now passed through
+  `helpers.replaceDollarTypesWithConcrete(f.type)`, matching the field's
+  declared type and resolving cleanly. The same fix is applied to the manual
+  `fromJson` cast path in `json_generator.dart`. Fixes #117.
+
 ## [2.0.1] - 2026-08-19
 
 ### Fix

--- a/zorphy/example/lib/various/issue117_ref/issue117_ref.dart
+++ b/zorphy/example/lib/various/issue117_ref/issue117_ref.dart
@@ -1,0 +1,15 @@
+// Regression fixture for issue #117: cross-file cross-entity reference.
+//
+// $Issue117Ref is declared in this file. Issue117Repro (in
+// issue117_repro.dart) references $Issue117Ref as a field type — the canonical
+// CLI-generated shape (FieldNormalizer prepends the $ prefix).
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+part 'issue117_ref.zorphy.dart';
+part 'issue117_ref.g.dart';
+
+@Zorphy(generateJson: true, generateCompareTo: true)
+abstract class $Issue117Ref {
+  String get id;
+}
+

--- a/zorphy/example/lib/various/issue117_repro/issue117_repro.dart
+++ b/zorphy/example/lib/various/issue117_repro/issue117_repro.dart
@@ -1,0 +1,33 @@
+// Regression fixture for issue #117: cross-file cross-entity reference.
+//
+// $Issue117Repro has a field 'ref' typed $Issue117Ref (the abstract form emitted
+// by the CLI FieldNormalizer). The source imports the referenced entity file.
+//
+// Before the fix (issue #117): the generated patchWithIssue117Repro emitted
+//   ref: _patchMap.containsKey(Issue117Repro$.ref)
+//       ? ((...) as $Issue117Ref)
+//       : this.ref,
+// where the cast target $Issue117Ref (the abstract supertype) could not be
+// assigned to the constructor parameter Issue117Ref (the concrete subtype),
+// producing:
+//   error - issue117_repro.zorphy.dart: The argument type 'Object' can't
+//     be assigned to the parameter type 'Issue117Ref'.
+//
+// After the fix: the patch generator emits the cast as
+//   ... as Issue117Ref
+// (the concrete form, via helpers.replaceDollarTypesWithConcrete), matching
+// the field's declared type and resolving cleanly.
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import '../issue117_ref/issue117_ref.dart';
+
+part 'issue117_repro.zorphy.dart';
+part 'issue117_repro.g.dart';
+
+/// Issue117Repro entity — cross-entity reference (issue #117 fixture)
+@Zorphy(generateJson: true, generateCompareTo: true)
+abstract class $Issue117Repro {
+  $Issue117Ref get ref;
+  bool get summarized;
+  String? get summary;
+}
+

--- a/zorphy/lib/src/generators/json_generator.dart
+++ b/zorphy/lib/src/generators/json_generator.dart
@@ -2,6 +2,7 @@ import 'package:code_builder/code_builder.dart';
 
 import '../ast/ast.dart';
 import '../common/NameType.dart';
+import '../helpers.dart' as helpers;
 import '../models/class_metadata.dart';
 import '../models/generation_config.dart';
 import 'base_generator.dart';
@@ -85,7 +86,7 @@ class JsonGenerator extends UniversalGenerator {
             final info = manualField.first.jsonKeyInfo!;
             final jsonFieldName = info.name ?? f.name;
             bodyLines.add(
-                "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
+                "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${helpers.replaceDollarTypesWithConcrete(f.type ?? 'dynamic')} : null,");
           } else {
             bodyLines.add('      ${f.name}: instance.${f.name},');
           }
@@ -244,7 +245,7 @@ class JsonGenerator extends UniversalGenerator {
           final info = manualField.first.jsonKeyInfo!;
           final jsonFieldName = info.name ?? f.name;
           bodyLines.add(
-              "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${f.type} : null,");
+              "      ${f.name}: json['$jsonFieldName'] != null ? ${info.fromJson}(json['$jsonFieldName'] as Map<String, dynamic>) as ${helpers.replaceDollarTypesWithConcrete(f.type ?? 'dynamic')} : null,");
         } else {
           bodyLines.add('      ${f.name}: instance.${f.name},');
         }

--- a/zorphy/lib/src/generators/patch_generator.dart
+++ b/zorphy/lib/src/generators/patch_generator.dart
@@ -94,7 +94,7 @@ class PatchGenerator extends ConcreteClassGenerator {
         final comma = i == fields.length - 1 ? '' : ',';
         if (interfaceFieldNames.contains(f.name)) {
           bodyLines.add(
-            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
+            "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${helpers.replaceDollarTypesWithConcrete(f.type ?? 'dynamic')} : this.${f.name}$comma",
           );
         } else {
           bodyLines.add('${f.name}: this.${f.name},');
@@ -138,7 +138,7 @@ class PatchGenerator extends ConcreteClassGenerator {
       final f = fields[i];
       final comma = i == fields.length - 1 ? '' : ',';
       bodyLines.add(
-        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${f.type} : this.${f.name}$comma",
+        "${f.name}: _patchMap.containsKey($enumName.${helpers.enumMemberName(f.name)}) ? ( (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Function) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}](this.${f.name}) : (_patchMap[$enumName.${helpers.enumMemberName(f.name)}] is Patch) ? _patchMap[$enumName.${helpers.enumMemberName(f.name)}].applyTo(this.${f.name}) : _patchMap[$enumName.${helpers.enumMemberName(f.name)}] ) as ${helpers.replaceDollarTypesWithConcrete(f.type ?? 'dynamic')} : this.${f.name}$comma",
       );
     }
 

--- a/zorphy/test/generation/issue_117_cross_entity_import_test.dart
+++ b/zorphy/test/generation/issue_117_cross_entity_import_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Regression test for issue #117: cross-entity reference cast emits the
+/// abstract `$Type` form, which the analyzer cannot assign to the concrete
+/// `Type` form (the field's declared type).
+///
+/// When a Zorphy entity declares a field whose type is the ABSTRACT form of
+/// another Zorphy entity (e.g. `$ArtifactRef get ref;` — the canonical shape
+/// emitted by the CLI `FieldNormalizer`, which prepends the `$` prefix to
+/// entity references), the generated `.zorphy.dart` part file previously
+/// emitted:
+///
+/// ```dart
+/// ref: _patchMap.containsKey(Entity$.ref)
+///     ? ((...) as $ArtifactRef)  // abstract supertype
+///     : this.ref,
+/// ```
+///
+/// The cast target `$ArtifactRef` is the abstract supertype declared in the
+/// source file; the field type is `ArtifactRef` (the concrete subtype
+/// generated in the part file). Assigning the supertype to a parameter of
+/// the subtype is an illegal downcast — the analyzer reports:
+///
+/// ```
+/// error - entity.zorphy.dart: The argument type 'Object' can't be
+///   assigned to the parameter type 'ArtifactRef'.
+/// ```
+///
+/// (The analyzer's downcast analysis reports `Object` because the field type
+/// `ArtifactRef` resolves to `Object` while the part file is being
+/// generated — see issue #351 background.)
+///
+/// The fix: emit the cast target via
+/// `helpers.replaceDollarTypesWithConcrete(f.type)` so it matches the
+/// field's declared (concrete) type. The fixture pair lives at
+/// `example/lib/various/issue117_ref/` and `example/lib/various/issue117_repro/`.
+void main() {
+  final reproFixture =
+      File('example/lib/various/issue117_repro/issue117_repro.zorphy.dart');
+
+  late String output;
+
+  setUpAll(() {
+    if (!reproFixture.existsSync()) {
+      fail(
+        'Fixture not generated. Run: cd example && '
+        'dart run build_runner build --delete-conflicting-outputs',
+      );
+    }
+    output = reproFixture.readAsStringSync();
+  });
+
+  group('issue #117 — cross-entity cast concrete form', () {
+    test('field declaration uses the concrete entity type', () {
+      expect(output, contains('final Issue117Ref ref;'));
+    });
+
+    test('patchWith cast target is the concrete entity type, not \$Type', () {
+      // The cast MUST be `as Issue117Ref` (concrete form) — the previous
+      // `as $Issue117Ref` (abstract form) caused argument_type_not_assignable.
+      // The dart formatter places `as Issue117Ref` on its own line, so we use
+      // a regex that matches across newlines.
+      expect(
+        RegExp(r'\)\s*as\s+Issue117Ref\b').hasMatch(output),
+        isTrue,
+        reason: 'patchWith cast must target the concrete Issue117Ref form',
+      );
+      expect(
+        RegExp(r'\)\s*as\s+\$Issue117Ref\b').hasMatch(output),
+        isFalse,
+        reason: 'patchWith cast must NOT target the abstract \$Issue117Ref form',
+      );
+    });
+
+    test('patchWithIssue117Repro references the patch enum by name', () {
+      expect(output, contains('Issue117Repro\$.ref'));
+    });
+
+    test('no InvalidType leaks into the generated patch', () {
+      expect(output, isNot(contains('InvalidType')));
+    });
+
+    test('copyWith parameter uses the concrete entity type', () {
+      expect(output, contains('Issue117Ref? ref,'));
+    });
+  });
+}

--- a/zorphy/test/generation/issue_119_subtype_cast_test.dart
+++ b/zorphy/test/generation/issue_119_subtype_cast_test.dart
@@ -1,0 +1,116 @@
+// Regression test for issue #119:
+// "patch_generator emits `as $Type?` cast with leading $ for
+//  explicit-subtype field types (compile error)"
+//
+// Root cause: when a field's type is an explicit-subtype class (declared with a
+// leading `$`, e.g. `$Credentials`), the generated `patchWith` cast used the raw
+// `$`-prefixed type name (`as $Credentials?`). The consuming file declares the
+// field with the trimmed name (`Credentials?`), so the cast referenced an
+// undefined identifier and the generated file failed to compile.
+//
+// Fix: the cast strips the leading `$` from the field type, keeping the
+// trailing `?` nullable marker, so it matches how the field is declared.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/patch_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+ClassMetadata _concreteMeta({
+  required String name,
+  required List<NameTypeClassComment> fields,
+}) {
+  final ownFieldNames = fields.map((f) => f.name).toSet();
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: false,
+    isSealed: false,
+    nonSealed: false,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: fields,
+    ownFieldNames: ownFieldNames,
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+  );
+}
+
+GenerationConfig _patchConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.valueObject,
+    autoId: false,
+    generateJson: false,
+    explicitToJson: false,
+    generateCopyWith: false,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: true,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: false,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+String _emitMethod(Method spec) {
+  final lib = Library((b) => b.body.add(spec));
+  return lib.accept(DartEmitter(useNullSafetySyntax: true)).toString();
+}
+
+void main() {
+  group('Issue #119 — patchWith cast strips leading \$ from subtype field types', () {
+    final generator = PatchGenerator();
+
+    test('main patchWith casts use the trimmed reference type', () {
+      final meta = _concreteMeta(
+        name: 'InitializationParams',
+        fields: [
+          NameTypeClassComment('credentials', r'$Credentials?', 'InitializationParams'),
+          NameTypeClassComment('settings', r'$Settings?', 'InitializationParams'),
+          NameTypeClassComment('label', 'String?', 'InitializationParams'),
+        ],
+      );
+      final specs = generator.generateSpec(
+        GenerationContext(metadata: meta, config: _patchConfig()),
+      );
+      final emitted = _emitMethod(specs.first as Method);
+
+      // Casts must use the trimmed reference type, not the raw subtype name.
+      expect(emitted, contains('as Credentials?'));
+      expect(emitted, contains('as Settings?'));
+      // The broken form (`as $Credentials?`) must never appear. A legit `$`
+      // only shows up in the field-enum name (e.g. `InitializationParams$`),
+      // never inside an `as` cast.
+      expect(emitted, isNot(contains(RegExp(r'as \$\w+\?'))));
+      // Non-subtype fields are unaffected.
+      expect(emitted, contains('as String?'));
+    });
+  });
+}


### PR DESCRIPTION
The generated `patchWith` cast for explicit-subtype fields referenced the raw `$`-prefixed type (`as $Credentials?`), which fails to compile because the field is declared trimmed (`Credentials?`). This fixes the cast to use the trimmed reference type and adds a regression test (test/generation/issue_119_subtype_cast_test.dart) guarding it.

Authored entirely through miki (inverse kimi) on the Daytona box: read_file, exec (streaming `dart test`), and commit all went through miki's surgeon arms, no local provider.