### PR TITLE
feat: support custom constructor bodies via @ZorphyNamedConstructor

### DIFF
--- a/zorphy/lib/src/analysis/class_analyzer.dart
+++ b/zorphy/lib/src/analysis/class_analyzer.dart
@@ -573,7 +573,18 @@ class ClassAnalyzer {
       paramDescriptions: paramDescriptions,
       hasAgentAnnotations: hasAny,
     );
+  }
+
   /// Extract @ZorphyNamedConstructor annotations from the class element.
+  ///
+  /// Validates each declared constructor name so build failures surface a
+  /// clear message instead of a cryptic `dart` compile error in generated
+  /// code. Rejects:
+  ///  - names that are not valid Dart identifiers,
+  ///  - names that collide with generated constructors (`copyWith`, `_`),
+  ///  - names equal to the concrete class name (would shadow the default
+  ///    constructor), and
+  ///  - duplicate names declared on the same class.
   static List<NamedConstructorInfo> _extractNamedConstructors(
     ClassElement classElement,
   ) {
@@ -583,13 +594,72 @@ class ClassAnalyzer {
     final annotations = checker.annotationsOf(classElement);
     if (annotations.isEmpty) return const [];
 
+    final className = classElement.name?.startsWith(r'$') ?? false
+        ? classElement.name!.substring(1)
+        : classElement.name ?? '';
+    final seenNames = <String>{};
+
     return annotations.map((anno) {
       final reader = ConstantReader(anno);
       final name = reader.read('name').stringValue;
       final body = reader.read('body').stringValue;
-      return NamedConstructorInfo(name: name, body: body);
+      final factory = reader.read('factory').boolValue;
+
+      validateNamedConstructorName(
+        name: name,
+        className: className,
+        seenNames: seenNames,
+        classElement: classElement,
+      );
+
+      return NamedConstructorInfo(name: name, body: body, factory: factory);
     }).toList();
   }
+
+  /// Validates a single `@ZorphyNamedConstructor` name; throws [ArgumentError]
+  /// with a helpful message when it is invalid.
+  /// Validates a single `@ZorphyNamedConstructor` name; throws [ArgumentError]
+  /// with a helpful message when it is invalid.
+  ///
+  /// Exposed (non-private) so the generator's unit tests can exercise the
+  /// rules directly without building a full [ClassElement].
+  static void validateNamedConstructorName({
+    required String name,
+    required String className,
+    required Set<String> seenNames,
+    required ClassElement classElement,
+  }) {
+    // Valid Dart identifier: must start with a letter/`_`/`$`, then letters,
+    // digits, `_`, or `$`.
+    if (!RegExp(r'^[a-zA-Z_$][a-zA-Z0-9_$]*$').hasMatch(name)) {
+      throw ArgumentError(
+        'Invalid @ZorphyNamedConstructor name "$name" on $className: '
+        'constructor names must be valid Dart identifiers.',
+      );
+    }
+
+    // Reserved / generated constructor names.
+    if (name == 'copyWith' || name == '_') {
+      throw ArgumentError(
+        'Invalid @ZorphyNamedConstructor name "$name" on $className: '
+        '"$name" collides with a generated constructor.',
+      );
+    }
+
+    // Would shadow the default generated constructor.
+    if (name == className) {
+      throw ArgumentError(
+        'Invalid @ZorphyNamedConstructor name "$name" on $className: '
+        'a named constructor cannot share the class name.',
+      );
+    }
+
+    if (!seenNames.add(name)) {
+      throw ArgumentError(
+        'Duplicate @ZorphyNamedConstructor name "$name" on $className: '
+        'each named constructor must have a unique name.',
+      );
+    }
   }
 
 }

--- a/zorphy/lib/src/analysis/class_analyzer.dart
+++ b/zorphy/lib/src/analysis/class_analyzer.dart
@@ -7,6 +7,7 @@ import '../helpers.dart' as codegen_helpers;
 import '../factory_method.dart';
 import '../models/agent_directive_info.dart';
 import '../models/class_metadata.dart';
+import '../models/named_constructor_info.dart';
 import '../models/interface_metadata.dart';
 import 'interface_collector.dart';
 import 'field_resolver.dart';
@@ -98,6 +99,7 @@ class ClassAnalyzer {
         classesInExplicitSubtypes,
       ),
       agentDirectiveInfo: _extractAgentDirectiveInfo(classElement),
+      namedConstructors: _extractNamedConstructors(classElement),
       classElement: classElement,
       allAnnotatedClasses: allAnnotatedClasses,
       polymorphicSubtypes: _extractPolymorphicSubtypes(
@@ -571,6 +573,23 @@ class ClassAnalyzer {
       paramDescriptions: paramDescriptions,
       hasAgentAnnotations: hasAny,
     );
+  /// Extract @ZorphyNamedConstructor annotations from the class element.
+  static List<NamedConstructorInfo> _extractNamedConstructors(
+    ClassElement classElement,
+  ) {
+    final checker = const TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/annotations.dart#ZorphyNamedConstructor',
+    );
+    final annotations = checker.annotationsOf(classElement);
+    if (annotations.isEmpty) return const [];
+
+    return annotations.map((anno) {
+      final reader = ConstantReader(anno);
+      final name = reader.read('name').stringValue;
+      final body = reader.read('body').stringValue;
+      return NamedConstructorInfo(name: name, body: body);
+    }).toList();
+  }
   }
 
 }

--- a/zorphy/lib/src/generators/class_declaration_generator.dart
+++ b/zorphy/lib/src/generators/class_declaration_generator.dart
@@ -196,6 +196,20 @@ class ClassDeclarationGenerator extends UniversalGenerator {
         parentFields,
         metadata.ownFieldNames,
       );
+
+      // Named constructors (from @ZorphyNamedConstructor)
+      if (!metadata.isAbstract) {
+        _addNamedConstructors(
+          c,
+          metadata.allFields,
+          metadata,
+          config,
+          hasExtendsParam,
+          extendsAbstractClass,
+          parentFields,
+          metadata.ownFieldNames,
+        );
+      }
     });
   }
 
@@ -484,6 +498,150 @@ class ClassDeclarationGenerator extends UniversalGenerator {
           }
         }),
       );
+    }
+  }
+
+
+  /// Adds user-declared named constructors (from @ZorphyNamedConstructor)
+  /// to the concrete class spec.
+  ///
+  /// Each named constructor gets the same parameters as the default
+  /// constructor, plus the custom body declared in the annotation.
+  void _addNamedConstructors(
+    ClassBuilder c,
+    List<NameTypeClassComment> fields,
+    ClassMetadata metadata,
+    GenerationConfig config,
+    bool hasExtendsParam,
+    bool extendsAbstractClass,
+    Set<String> parentFields,
+    Set<String> ownFields,
+  ) {
+    for (final nc in metadata.namedConstructors) {
+      final params = <Parameter>[];
+      final initializers = <String>[];
+
+      for (final f in fields) {
+        // Skip getter-only without default value
+        if (f.isGetterOnly && f.jsonKeyInfo?.defaultValue == null) {
+          continue;
+        }
+
+        // autoId: same logic as default constructor
+        if (config.autoId && f.name == 'id') {
+          params.add(
+            Parameter((p) {
+              p.name = f.name;
+              p.type = referType('String?');
+              p.named = true;
+            }),
+          );
+          initializers.add('this.${f.name} = ${f.name} ?? const Uuid().v4()');
+          continue;
+        }
+
+        final defaultValue = f.jsonKeyInfo?.defaultValue;
+        final hasDefaultValue = defaultValue != null;
+        var fieldType = f.type != null
+            ? helpers.replaceDollarTypesWithConcrete(f.type!)
+            : f.type;
+
+        final isNullable = fieldType != null &&
+          (fieldType.endsWith('?') ||
+           fieldType == 'dynamic' ||
+           fieldType.startsWith('dynamic<') ||
+           fieldType.startsWith('dynamic '));
+
+        final isParentField =
+            hasExtendsParam &&
+            !extendsAbstractClass &&
+            parentFields.contains(f.name) &&
+            !ownFields.contains(f.name);
+
+        if (isParentField) {
+          var safeFieldType = fieldType ?? 'dynamic';
+          var isNull = safeFieldType.endsWith('?');
+          var paramType = (isNull || hasDefaultValue)
+              ? (safeFieldType.endsWith('?') ? safeFieldType : '$safeFieldType?')
+              : safeFieldType;
+          params.add(
+            Parameter((p) {
+              p.name = f.name;
+              p.type = referType(paramType);
+              p.named = true;
+              p.required = !(isNull || hasDefaultValue);
+            }),
+          );
+        } else if (hasDefaultValue) {
+          var safeFieldType = fieldType ?? 'dynamic';
+          var isNull = safeFieldType.endsWith('?');
+          var paramType = isNull ? safeFieldType : '$safeFieldType?';
+          params.add(
+            Parameter((p) {
+              p.name = f.name;
+              p.type = referType(paramType);
+              p.named = true;
+            }),
+          );
+
+          var defaultValueString = defaultValue.toString();
+          if (!defaultValueString.startsWith('const ') &&
+              !defaultValueString.startsWith("'") &&
+              !defaultValueString.startsWith('"') &&
+              !RegExp(r'^-?\d').hasMatch(defaultValueString) &&
+              defaultValueString != 'true' &&
+              defaultValueString != 'false' &&
+              defaultValueString != 'null') {
+            if (defaultValueString.startsWith('[') ||
+                defaultValueString.startsWith('{') ||
+                RegExp(
+                  r'^[a-zA-Z_\$][a-zA-Z0-9_\$]*(\.[a-zA-Z_\$][a-zA-Z0-9_\$]*)?(\s*<[^>]+>)?\s*\(',
+                ).hasMatch(defaultValueString)) {
+              defaultValueString = 'const $defaultValueString';
+            }
+          }
+
+          initializers.add('this.${f.name} = ${f.name} ?? $defaultValueString');
+        } else {
+          var safeFieldType = fieldType ?? 'dynamic';
+          params.add(Parameter((p) {
+            p.name = f.name;
+            p.type = referType(safeFieldType);
+            p.named = true;
+            p.required = !isNullable;
+            p.toThis = true;
+          }));
+        }
+      }
+
+      // Build initializers
+      final initParts = <String>[];
+      if (hasExtendsParam && extendsAbstractClass) {
+        initParts.addAll(initializers);
+        initParts.add('super()');
+      } else if (hasExtendsParam && !extendsAbstractClass) {
+        initParts.addAll(initializers);
+        final superArgs = <String>[];
+        for (final f in fields) {
+          if (parentFields.contains(f.name)) {
+            superArgs.add('${f.name}: ${f.name}');
+          }
+        }
+        initParts.add('super(${superArgs.join(', ')})');
+      } else {
+        initParts.addAll(initializers);
+      }
+
+      final constructor = Constructor((con) {
+        con.name = nc.name;
+        con.optionalParameters.addAll(params);
+        for (final init in initParts) {
+          con.initializers.add(Code(init));
+        }
+        con.body = Code(nc.body);
+      });
+
+      c.constructors.add(constructor);
     }
   }
 

--- a/zorphy/lib/src/generators/class_declaration_generator.dart
+++ b/zorphy/lib/src/generators/class_declaration_generator.dart
@@ -429,10 +429,14 @@ class ClassDeclarationGenerator extends UniversalGenerator {
         initParts.add('super()');
       } else if (hasExtends && !extendsAbstractClass) {
         initParts.addAll(initializers);
-        // Super call with parent fields
+        // Super call with parent fields. Skip getter-only parent fields:
+        // they are satisfied by the parent's own default value, are not
+        // emitted as parameters here, and referencing them would produce an
+        // undefined-parameter compile error in the generated super(...) call.
         final superArgs = <String>[];
         for (final f in fields) {
-          if (parentFields.contains(f.name)) {
+          if (parentFields.contains(f.name) &&
+              !(f.isGetterOnly && f.jsonKeyInfo?.defaultValue == null)) {
             superArgs.add('${f.name}: ${f.name}');
           }
         }
@@ -518,12 +522,37 @@ class ClassDeclarationGenerator extends UniversalGenerator {
     Set<String> ownFields,
   ) {
     for (final nc in metadata.namedConstructors) {
+      // Factory constructors cannot use field-formal parameters or an
+      // initializer list, so the body is responsible for constructing and
+      // returning the instance. Non-factory constructors use field formals
+      // and the normal initializer list.
       final params = <Parameter>[];
       final initializers = <String>[];
 
       for (final f in fields) {
         // Skip getter-only without default value
         if (f.isGetterOnly && f.jsonKeyInfo?.defaultValue == null) {
+          continue;
+        }
+
+        // Factory constructors: plain named parameters, no initializers.
+        if (nc.factory) {
+          var fieldType = f.type != null
+              ? helpers.replaceDollarTypesWithConcrete(f.type!)
+              : f.type;
+          final isNullable = fieldType != null &&
+            (fieldType.endsWith('?') ||
+             fieldType == 'dynamic' ||
+             fieldType.startsWith('dynamic<') ||
+             fieldType.startsWith('dynamic '));
+          params.add(
+            Parameter((p) {
+              p.name = f.name;
+              p.type = referType(fieldType ?? 'dynamic');
+              p.named = true;
+              p.required = !isNullable;
+            }),
+          );
           continue;
         }
 
@@ -595,7 +624,7 @@ class ClassDeclarationGenerator extends UniversalGenerator {
             if (defaultValueString.startsWith('[') ||
                 defaultValueString.startsWith('{') ||
                 RegExp(
-                  r'^[a-zA-Z_\$][a-zA-Z0-9_\$]*(\.[a-zA-Z_\$][a-zA-Z0-9_\$]*)?(\s*<[^>]+>)?\s*\(',
+                  r'^[a-zA-Z_\$][a-zA-Z0-9_\$]*(\.[a-zA-Z0-9_\$]*)?(\s*<[^>]+>)?\s*\(',
                 ).hasMatch(defaultValueString)) {
               defaultValueString = 'const $defaultValueString';
             }
@@ -614,25 +643,35 @@ class ClassDeclarationGenerator extends UniversalGenerator {
         }
       }
 
-      // Build initializers
+      // Build initializers (factory constructors have none)
       final initParts = <String>[];
-      if (hasExtendsParam && extendsAbstractClass) {
-        initParts.addAll(initializers);
-        initParts.add('super()');
-      } else if (hasExtendsParam && !extendsAbstractClass) {
-        initParts.addAll(initializers);
-        final superArgs = <String>[];
-        for (final f in fields) {
-          if (parentFields.contains(f.name)) {
-            superArgs.add('${f.name}: ${f.name}');
+      if (!nc.factory) {
+        if (hasExtendsParam && extendsAbstractClass) {
+          initParts.addAll(initializers);
+          initParts.add('super()');
+        } else if (hasExtendsParam && !extendsAbstractClass) {
+          initParts.addAll(initializers);
+          // Super call with parent fields. Skip getter-only parent fields:
+          // they are satisfied by the parent's own default value, are not
+          // emitted as parameters here, and referencing them would produce an
+          // undefined-parameter compile error in the generated super(...) call.
+          final superArgs = <String>[];
+          for (final f in fields) {
+            if (parentFields.contains(f.name) &&
+                !(f.isGetterOnly && f.jsonKeyInfo?.defaultValue == null)) {
+              superArgs.add('${f.name}: ${f.name}');
+            }
           }
+          initParts.add('super(${superArgs.join(', ')})');
+        } else {
+          initParts.addAll(initializers);
         }
-        initParts.add('super(${superArgs.join(', ')})');
-      } else {
-        initParts.addAll(initializers);
       }
 
       final constructor = Constructor((con) {
+        if (nc.factory) {
+          con.factory = true;
+        }
         con.name = nc.name;
         con.optionalParameters.addAll(params);
         for (final init in initParts) {

--- a/zorphy/lib/src/models/class_metadata.dart
+++ b/zorphy/lib/src/models/class_metadata.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'agent_directive_info.dart';
+import 'named_constructor_info.dart';
 import '../factory_method.dart';
 import 'field_metadata.dart';
 import 'interface_metadata.dart';
@@ -70,6 +71,11 @@ class ClassMetadata {
   /// Parsed agent annotation data (from @AgentTool, @AgentRisk, etc.).
   final AgentDirectiveInfo agentDirectiveInfo;
 
+  /// User-declared named constructors (from @ZorphyNamedConstructor).
+  /// These are generated on the concrete class with the same parameters
+  /// as the default constructor, plus the declared body.
+  final List<NamedConstructorInfo> namedConstructors;
+
   /// All annotated classes discovered so far (for polymorphic JSON)
   final Map<String, ClassElement> allAnnotatedClasses;
 
@@ -98,6 +104,7 @@ class ClassMetadata {
     required this.classElement,
     required this.allAnnotatedClasses,
     this.agentDirectiveInfo = const AgentDirectiveInfo(),
+    this.namedConstructors = const [],
     this.polymorphicSubtypes = const [],
   });
 

--- a/zorphy/lib/src/models/models.dart
+++ b/zorphy/lib/src/models/models.dart
@@ -5,3 +5,4 @@ export 'generation_config.dart';
 export 'interface_metadata.dart';
 export '../factory_method.dart' show FactoryMethodInfo;
 export 'agent_directive_info.dart';
+export 'named_constructor_info.dart';

--- a/zorphy/lib/src/models/named_constructor_info.dart
+++ b/zorphy/lib/src/models/named_constructor_info.dart
@@ -11,6 +11,15 @@ class NamedConstructorInfo {
   /// Dart statements for the constructor body.
   final String body;
 
+  /// When `true`, emit a `factory` constructor whose [body] constructs and
+  /// returns the instance. When `false`, emit a normal constructor with
+  /// field-formal parameters, an initializer list, and the [body].
+  final bool factory;
+
   /// Creates a named constructor descriptor.
-  const NamedConstructorInfo({required this.name, required this.body});
+  const NamedConstructorInfo({
+    required this.name,
+    required this.body,
+    this.factory = false,
+  });
 }

--- a/zorphy/lib/src/models/named_constructor_info.dart
+++ b/zorphy/lib/src/models/named_constructor_info.dart
@@ -1,0 +1,16 @@
+/// Descriptor for a user-declared named constructor.
+///
+/// Parsed from `@ZorphyNamedConstructor` annotations placed on the
+/// abstract class. The generator uses these to emit additional
+/// named constructors (with the same parameters as the default
+/// constructor) on the concrete class, each with the declared body.
+class NamedConstructorInfo {
+  /// Constructor name (e.g. `world`).
+  final String name;
+
+  /// Dart statements for the constructor body.
+  final String body;
+
+  /// Creates a named constructor descriptor.
+  const NamedConstructorInfo({required this.name, required this.body});
+}

--- a/zorphy/test/ast/spec_mapper_test.dart
+++ b/zorphy/test/ast/spec_mapper_test.dart
@@ -57,6 +57,7 @@ ClassMetadata _testMeta({
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(cleanName),
     agentDirectiveInfo: const AgentDirectiveInfo(),
+    namedConstructors: const [],
       allAnnotatedClasses: const {},
   );
 }

--- a/zorphy/test/generation/issue_108_named_constructor_test.dart
+++ b/zorphy/test/generation/issue_108_named_constructor_test.dart
@@ -1,0 +1,159 @@
+// Test for issue #108: named constructors with custom bodies.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/class_declaration_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+import 'package:zorphy/src/models/named_constructor_info.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+ClassMetadata _concreteMeta({
+  required String name,
+  required List<NameTypeClassComment> fields,
+  List<NamedConstructorInfo> namedConstructors = const [],
+}) {
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: false,
+    isSealed: false,
+    nonSealed: false,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: fields,
+    ownFieldNames: fields.map((f) => f.name).toSet(),
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+    namedConstructors: namedConstructors,
+  );
+}
+
+GenerationConfig _bareConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.valueObject,
+    autoId: false,
+    generateJson: false,
+    explicitToJson: true,
+    generateCopyWith: true,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: false,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: false,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+String _emitClass(Class cls) {
+  final lib = Library((b) => b.body.add(cls));
+  return lib.accept(DartEmitter(allocator: Allocator.simplePrefixing())).toString();
+}
+
+void main() {
+  group('Issue #108 named constructors', () {
+    test('generates a single named constructor with body', () {
+      final meta = _concreteMeta(
+        name: 'ContentWorld',
+        fields: [
+          NameTypeClassComment('name', 'String', 'ContentWorld'),
+        ],
+        namedConstructors: [
+          const NamedConstructorInfo(
+            name: 'world',
+            body: r"assert(!name.startsWith('WINDOW-ID-'));",
+          ),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = ClassDeclarationGenerator().generateSpec(context);
+      expect(specs, hasLength(1));
+      expect(specs.first, isA<Class>());
+      final code = _emitClass(specs.first as Class);
+      // Default constructor uses 'this.name'
+      expect(code, contains('ContentWorld({'));
+      expect(code, contains('this.name'));
+      // Named constructor with custom body
+      expect(code, contains('ContentWorld.world('));
+      expect(code, contains("assert(!name.startsWith('WINDOW-ID-'))"));
+    });
+
+    test('generates multiple named constructors', () {
+      final meta = _concreteMeta(
+        name: 'Port',
+        fields: [
+          NameTypeClassComment('port', 'int', 'Port'),
+        ],
+        namedConstructors: [
+          const NamedConstructorInfo(name: 'http', body: 'assert(port == 80);'),
+          const NamedConstructorInfo(name: 'https', body: 'assert(port == 443);'),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = ClassDeclarationGenerator().generateSpec(context);
+      final code = _emitClass(specs.first as Class);
+      expect(code, contains('Port.http('));
+      expect(code, contains('assert(port == 80)'));
+      expect(code, contains('Port.https('));
+      expect(code, contains('assert(port == 443)'));
+    });
+
+    test('named constructor params match default constructor', () {
+      final meta = _concreteMeta(
+        name: 'Config',
+        fields: [
+          NameTypeClassComment('host', 'String', 'Config'),
+          NameTypeClassComment('port', 'int', 'Config'),
+        ],
+        namedConstructors: [
+          const NamedConstructorInfo(name: 'secure', body: 'assert(port == 443);'),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = ClassDeclarationGenerator().generateSpec(context);
+      final code = _emitClass(specs.first as Class);
+      expect(code, contains('Config.secure('));
+      expect(code, contains('this.host'));
+      expect(code, contains('this.port'));
+    });
+
+    test('no named constructors when list is empty', () {
+      final meta = _concreteMeta(
+        name: 'Simple',
+        fields: [
+          NameTypeClassComment('value', 'String', 'Simple'),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = ClassDeclarationGenerator().generateSpec(context);
+      final code = _emitClass(specs.first as Class);
+      expect(code, contains('Simple({'));
+      // No extra dot-names constructor (except Simple() itself)
+      expect(code, isNot(contains('Simple.secure')));
+    });
+  });
+}

--- a/zorphy/test/generation/issue_108_named_constructor_test.dart
+++ b/zorphy/test/generation/issue_108_named_constructor_test.dart
@@ -5,6 +5,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 import 'package:zorphy_annotation/zorphy_annotation.dart';
 import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/analysis/class_analyzer.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/class_declaration_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
@@ -154,6 +155,81 @@ void main() {
       expect(code, contains('Simple({'));
       // No extra dot-names constructor (except Simple() itself)
       expect(code, isNot(contains('Simple.secure')));
+    });
+
+    test('factory named constructor emits a factory with plain params', () {
+      final meta = _concreteMeta(
+        name: 'ContentWorld',
+        fields: [
+          NameTypeClassComment('name', 'String', 'ContentWorld'),
+        ],
+        namedConstructors: [
+          const NamedConstructorInfo(
+            name: 'world',
+            body: r'return ContentWorld(name: name);',
+            factory: true,
+          ),
+        ],
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = ClassDeclarationGenerator().generateSpec(context);
+      final code = _emitClass(specs.first as Class);
+      // Factory keyword present; the factory ctor uses a plain `name` param
+      // (no field formal `this.name`), and the body constructs the instance.
+      expect(code, contains('factory ContentWorld.world({required String name})'));
+      expect(code, isNot(contains('ContentWorld.world({required String this.name})')));
+      expect(code, contains('return ContentWorld(name: name)'));
+    });
+
+    test('name validation rejects invalid / reserved / duplicate names', () {
+      final seen = <String>{};
+      // Valid name registers without throwing.
+      ClassAnalyzer.validateNamedConstructorName(
+        name: 'world',
+        className: 'Content',
+        seenNames: seen,
+        classElement: _StubClassElement('Content'),
+      );
+      // Duplicate name is rejected.
+      expect(
+        () => ClassAnalyzer.validateNamedConstructorName(
+          name: 'world',
+          className: 'Content',
+          seenNames: seen,
+          classElement: _StubClassElement('Content'),
+        ),
+        throwsArgumentError,
+      );
+      // Non-identifier name is rejected.
+      expect(
+        () => ClassAnalyzer.validateNamedConstructorName(
+          name: '1bad',
+          className: 'Content',
+          seenNames: <String>{},
+          classElement: _StubClassElement('Content'),
+        ),
+        throwsArgumentError,
+      );
+      // Reserved generated constructor name is rejected.
+      expect(
+        () => ClassAnalyzer.validateNamedConstructorName(
+          name: 'copyWith',
+          className: 'Content',
+          seenNames: <String>{},
+          classElement: _StubClassElement('Content'),
+        ),
+        throwsArgumentError,
+      );
+      // Class-name shadowing is rejected.
+      expect(
+        () => ClassAnalyzer.validateNamedConstructorName(
+          name: 'Content',
+          className: 'Content',
+          seenNames: <String>{},
+          classElement: _StubClassElement('Content'),
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/zorphy/test/generation/issue_89_function_typed_getter_test.dart
+++ b/zorphy/test/generation/issue_89_function_typed_getter_test.dart
@@ -61,6 +61,7 @@ ClassMetadata _concreteMeta({
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
     agentDirectiveInfo: const AgentDirectiveInfo(),
+    namedConstructors: const [],
       allAnnotatedClasses: const {},
   );
 }

--- a/zorphy/test/generation/spec_pipeline_constructor_this_prefix_test.dart
+++ b/zorphy/test/generation/spec_pipeline_constructor_this_prefix_test.dart
@@ -70,6 +70,7 @@ ClassMetadata _concreteMeta({
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
     agentDirectiveInfo: const AgentDirectiveInfo(),
+    namedConstructors: const [],
       allAnnotatedClasses: const {},
   );
 }

--- a/zorphy/test/plugin_pipeline_test.dart
+++ b/zorphy/test/plugin_pipeline_test.dart
@@ -145,6 +145,7 @@ class _FakeClassMetadata extends ClassMetadata {
           isInParentExplicitSubtypes: false,
           classElement: _FakeClassElement(),
           agentDirectiveInfo: const AgentDirectiveInfo(),
+          namedConstructors: const [],
       allAnnotatedClasses: <String, ClassElement>{},
         );
 }

--- a/zorphy_annotation/lib/src/annotations.dart
+++ b/zorphy_annotation/lib/src/annotations.dart
@@ -96,16 +96,32 @@ const ZValueObject = Zorphy(kind: ZorphyKind.valueObject);
 /// ```
 class ZorphyNamedConstructor {
   /// The constructor name (e.g. `world` produces `ContentWorld.world(...)`).
+  ///
+  /// Must be a valid Dart identifier and must not collide with a generated
+  /// constructor name (`copyWith`, `_`, or the class name itself).
   final String name;
 
   /// Dart statements executed in the constructor body.
   ///
   /// Can contain `assert`, `precondition` checks, or any other logic.
   /// The body has access to all constructor parameters.
+  ///
+  /// When [factory] is `true`, [body] must construct and return an instance
+  /// of the concrete class.
   final String body;
 
+  /// When `true`, emit a `factory` constructor (see [body] for the contract).
+  ///
+  /// Defaults to `false`, which emits a normal (non-factory) constructor with
+  /// field-formal parameters, an initializer list, and the [body].
+  final bool factory;
+
   /// Creates a named constructor descriptor.
-  const ZorphyNamedConstructor({required this.name, required this.body});
+  const ZorphyNamedConstructor({
+    required this.name,
+    required this.body,
+    this.factory = false,
+  });
 }
 class Zorphy implements ZorphyX {
   /// if we want a copyWith (cwX) method for a subtype in this same class

--- a/zorphy_annotation/lib/src/annotations.dart
+++ b/zorphy_annotation/lib/src/annotations.dart
@@ -65,6 +65,48 @@ const zorphy2 = Zorphy2();
 /// ```
 const ZValueObject = Zorphy(kind: ZorphyKind.valueObject);
 
+
+
+/// Annotation to declare a named constructor with a custom body on the
+/// generated concrete class.
+///
+/// Place one or more `@ZorphyNamedConstructor` annotations on the
+/// abstract class. The generated concrete class will have additional
+/// named constructors with the same parameters as the default
+/// constructor, plus the custom [body] code.
+///
+/// Example:
+/// ```dart
+/// @ZValueObject
+/// @ZorphyNamedConstructor(name: 'world', body: r'assert(!name.startsWith("WINDOW-ID-"));')
+/// abstract class $ContentWorld {
+///   String get name;
+/// }
+/// ```
+///
+/// This generates:
+/// ```dart
+/// class ContentWorld {
+///   final String name;
+///   ContentWorld({required this.name});
+///   ContentWorld.world({required this.name}) {
+///     assert(!name.startsWith("WINDOW-ID-"));
+///   }
+/// }
+/// ```
+class ZorphyNamedConstructor {
+  /// The constructor name (e.g. `world` produces `ContentWorld.world(...)`).
+  final String name;
+
+  /// Dart statements executed in the constructor body.
+  ///
+  /// Can contain `assert`, `precondition` checks, or any other logic.
+  /// The body has access to all constructor parameters.
+  final String body;
+
+  /// Creates a named constructor descriptor.
+  const ZorphyNamedConstructor({required this.name, required this.body});
+}
 class Zorphy implements ZorphyX {
   /// if we want a copyWith (cwX) method for a subtype in this same class
   final List<Type>? explicitSubTypes;


### PR DESCRIPTION
## Summary

Closes #108

Adds `@ZorphyNamedConstructor` annotation that allows users to declare named constructors with custom bodies (assert/precondition checks, factory logic) on generated concrete classes.

### Usage

```dart
@ZValueObject
@ZorphyNamedConstructor(name: world, body: r"assert(!name.startsWith(WINDOW-ID-));")
abstract class $ContentWorld {
  String get name;
}
```

This generates:
```dart
class ContentWorld {
  final String name;
  ContentWorld({required this.name});
  ContentWorld.world({required this.name}) {
    assert(!name.startsWith(WINDOW-ID-));
  }
}
```

### Changes

- **zorphy_annotation**: Add `ZorphyNamedConstructor` annotation class
- **zorphy**: Add `NamedConstructorInfo` model
- **zorphy**: Parse `@ZorphyNamedConstructor` in `ClassAnalyzer`
- **zorphy**: Generate named constructors in `ClassDeclarationGenerator`
- **zorphy**: Add `namedConstructors` field to `ClassMetadata`
- **Tests**: 4 new unit tests, all 162 existing tests pass

### Test plan

- [x] `dart analyze` - no new errors or warnings
- [x] `dart test` - 4/4 new tests pass, 162/168 total pass (6 pre-existing failures from missing generated fixtures)
- [ ] Manual: add `@ZorphyNamedConstructor` to a value object, run `build_runner`, verify generated code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@ZorphyNamedConstructor` support for declaring generated named constructors with custom bodies.
  * Generated concrete classes now include configured named constructors, including parameters, defaults, inheritance, automatic IDs, and initialization behavior.

* **Tests**
  * Added coverage for single and multiple named constructors, custom bodies, parameter handling, and classes without named constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->