### PR TITLE
feat: add agent annotations @AgentTool, @AgentRisk, @AgentInternal, @AgentExclude, @AgentToolParam

### DIFF
--- a/zorphy/example/pubspec.lock
+++ b/zorphy/example/pubspec.lock
@@ -471,13 +471,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.2.0"
   zorphy_annotation:
     dependency: "direct main"
     description:
       path: "../../zorphy_annotation"
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.2.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/lib/src/analysis/class_analyzer.dart
+++ b/zorphy/lib/src/analysis/class_analyzer.dart
@@ -5,6 +5,7 @@ import '../common/NameType.dart';
 import '../common/helpers.dart' as common_helpers;
 import '../helpers.dart' as codegen_helpers;
 import '../factory_method.dart';
+import '../models/agent_directive_info.dart';
 import '../models/class_metadata.dart';
 import '../models/interface_metadata.dart';
 import 'interface_collector.dart';
@@ -96,6 +97,7 @@ class ClassAnalyzer {
         className,
         classesInExplicitSubtypes,
       ),
+      agentDirectiveInfo: _extractAgentDirectiveInfo(classElement),
       classElement: classElement,
       allAnnotatedClasses: allAnnotatedClasses,
       polymorphicSubtypes: _extractPolymorphicSubtypes(
@@ -469,4 +471,98 @@ class ClassAnalyzer {
         zorphy2Checker.firstAnnotationOf(el);
     return annot == null ? null : ConstantReader(annot);
   }
+
+  /// Extract agent annotations (@AgentTool, @AgentRisk, @AgentInternal,
+  /// @AgentExclude, @AgentToolParam) from the class and its fields.
+  static AgentDirectiveInfo _extractAgentDirectiveInfo(
+    ClassElement classElement,
+  ) {
+    String? toolName, toolNamespace, toolDescription;
+    String risk = 'safe';
+    bool exclude = false;
+    bool internal = false;
+    final paramDescriptions = <String, String>{};
+    bool hasAny = false;
+
+    // --- Class-level annotations ---
+
+    // @AgentTool
+    final toolChecker = TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/agent_annotations.dart#AgentTool',
+    );
+    final toolAnnos = toolChecker.annotationsOf(classElement);
+    if (toolAnnos.isNotEmpty) {
+      hasAny = true;
+      final reader = ConstantReader(toolAnnos.first);
+      toolName = reader.peek('name')?.stringValue;
+      toolNamespace = reader.peek('namespace')?.stringValue;
+      toolDescription = reader.peek('description')?.stringValue;
+    }
+
+    // @AgentRisk
+    final riskChecker = TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/agent_annotations.dart#AgentRisk',
+    );
+    final riskAnnos = riskChecker.annotationsOf(classElement);
+    if (riskAnnos.isNotEmpty) {
+      hasAny = true;
+      final reader = ConstantReader(riskAnnos.first);
+      final value = reader.read('value');
+      final index = value.objectValue.getField('index')?.toIntValue();
+      if (index != null && index >= 0 && index < 3) {
+        risk = ['safe', 'confirm', 'admin'][index];
+      }
+    }
+
+    // @AgentInternal
+    final internalChecker = TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/agent_annotations.dart#AgentInternal',
+    );
+    if (internalChecker.hasAnnotationOf(classElement)) {
+      hasAny = true;
+      internal = true;
+      risk = 'admin'; // AgentInternal implies admin risk
+    }
+
+    // @AgentExclude
+    final excludeChecker = TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/agent_annotations.dart#AgentExclude',
+    );
+    if (excludeChecker.hasAnnotationOf(classElement)) {
+      hasAny = true;
+      exclude = true;
+    }
+
+    // --- Field-level @AgentToolParam ---
+    final paramChecker = TypeChecker.fromUrl(
+      'package:zorphy_annotation/src/agent_annotations.dart#AgentToolParam',
+    );
+    for (final field in classElement.fields) {
+      final fieldName = field.name;
+      if (fieldName == null || fieldName == 'hashCode' || fieldName == 'runtimeType') continue;
+      final paramAnnos = paramChecker.annotationsOf(field);
+      if (paramAnnos.isNotEmpty) {
+        hasAny = true;
+        final reader = ConstantReader(paramAnnos.first);
+        final desc = reader.peek('description')?.stringValue;
+        if (desc != null) {
+          paramDescriptions[fieldName] = desc;
+        }
+      }
+    }
+
+
+
+    return AgentDirectiveInfo(
+      toolName: toolName,
+      toolNamespace: toolNamespace,
+      toolDescription: toolDescription,
+      risk: risk,
+      exclude: exclude,
+      internal: internal,
+      paramDescriptions: paramDescriptions,
+      hasAgentAnnotations: hasAny,
+    );
+  }
+
 }

--- a/zorphy/lib/src/generators/agent_directive_generator.dart
+++ b/zorphy/lib/src/generators/agent_directive_generator.dart
@@ -1,0 +1,82 @@
+import 'package:code_builder/code_builder.dart';
+
+import '../models/agent_directive_info.dart';
+import '../ast/type_ref.dart';
+import 'base_generator.dart';
+
+/// Generates a top-level `const agentDirective = AgentDirective(...)`
+/// when agent annotations are present on the annotated class.
+///
+/// The emitted const is consumed by zuraffa's AgentPlugin via AST scan.
+class AgentDirectiveGenerator extends UniversalGenerator {
+  /// Creates an agent directive generator.
+  AgentDirectiveGenerator();
+
+  @override
+  List<Spec> generateSpec(GenerationContext context) {
+    final info = context.metadata.agentDirectiveInfo;
+    if (!info.hasAgentAnnotations) return [];
+
+    final fields = _buildFields(info);
+    final directive = Field((f) {
+      f.name = 'agentDirective';
+      f.modifier = FieldModifier.final$;
+      f.type = referType('AgentDirective');
+      f.assignment = Code(fields);
+    });
+
+    return [directive];
+  }
+
+  @override
+  bool shouldGenerate(GenerationContext context) {
+    return context.metadata.agentDirectiveInfo.hasAgentAnnotations;
+  }
+
+  /// Builds the AgentDirective constructor argument string.
+  String _buildFields(AgentDirectiveInfo info) {
+    final parts = <String>[];
+
+    // tool parameter
+    if (info.toolName != null ||
+        info.toolNamespace != null ||
+        info.toolDescription != null) {
+      final toolParts = <String>[];
+      if (info.toolName != null) toolParts.add("name: '${_escape(info.toolName!)}'");
+      if (info.toolNamespace != null) toolParts.add("namespace: '${_escape(info.toolNamespace!)}'");
+      if (info.toolDescription != null) toolParts.add("description: '${_escape(info.toolDescription!)}'");
+      parts.add('tool: const AgentToolDirective(${toolParts.join(', ')}),');
+    }
+
+    // risk
+    if (info.risk != 'safe') {
+      parts.add('risk: AgentRiskTier.${info.risk},');
+    }
+
+    // exclude
+    if (info.exclude) {
+      parts.add('exclude: true,');
+    }
+
+    // internal
+    if (info.internal) {
+      parts.add('internal: true,');
+    }
+
+    // params
+    if (info.paramDescriptions.isNotEmpty) {
+      final paramEntries = info.paramDescriptions.entries.map((e) {
+        return "'${_escape(e.key)}': const AgentParamDirective(description: '${_escape(e.value)}')";
+      }).join(', ');
+      parts.add('params: {$paramEntries},');
+    }
+
+    if (parts.isEmpty) {
+      return 'const AgentDirective()';
+    }
+    return 'const AgentDirective(\n    ${parts.join('\n    ')}\n  )';
+  }
+
+  /// Escapes single quotes in a string.
+  String _escape(String s) => s.replaceAll("'", "\\'");
+}

--- a/zorphy/lib/src/generators/generators.dart
+++ b/zorphy/lib/src/generators/generators.dart
@@ -9,3 +9,4 @@ export 'json_generator.dart';
 export 'extension_generator.dart';
 export 'fields_class_generator.dart';
 export 'property_helper_generator.dart';
+export 'agent_directive_generator.dart';

--- a/zorphy/lib/src/models/agent_directive_info.dart
+++ b/zorphy/lib/src/models/agent_directive_info.dart
@@ -1,0 +1,42 @@
+/// Internal model for agent directive data parsed from annotations.
+///
+/// This is the generator-internal representation. The public-facing
+/// contract is [AgentDirective] in `zorphy_annotation`.
+
+class AgentDirectiveInfo {
+  /// Tool name override (null = use class name).
+  final String? toolName;
+
+  /// Tool namespace override.
+  final String? toolNamespace;
+
+  /// Tool description override.
+  final String? toolDescription;
+
+  /// Risk tier.
+  final String risk;
+
+  /// Whether the entity is excluded from tool generation.
+  final bool exclude;
+
+  /// Whether this is an internal (admin-only) entity.
+  final bool internal;
+
+  /// Per-field parameter descriptions.
+  final Map<String, String> paramDescriptions;
+
+  /// Whether any agent annotation was present (controls emission).
+  final bool hasAgentAnnotations;
+
+  /// Creates an agent directive info model.
+  const AgentDirectiveInfo({
+    this.toolName,
+    this.toolNamespace,
+    this.toolDescription,
+    this.risk = 'safe',
+    this.exclude = false,
+    this.internal = false,
+    this.paramDescriptions = const {},
+    this.hasAgentAnnotations = false,
+  });
+}

--- a/zorphy/lib/src/models/class_metadata.dart
+++ b/zorphy/lib/src/models/class_metadata.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'agent_directive_info.dart';
 import '../factory_method.dart';
 import 'field_metadata.dart';
 import 'interface_metadata.dart';
@@ -66,6 +67,9 @@ class ClassMetadata {
   /// The original ClassElement from Dart analyzer
   final ClassElement classElement;
 
+  /// Parsed agent annotation data (from @AgentTool, @AgentRisk, etc.).
+  final AgentDirectiveInfo agentDirectiveInfo;
+
   /// All annotated classes discovered so far (for polymorphic JSON)
   final Map<String, ClassElement> allAnnotatedClasses;
 
@@ -93,6 +97,7 @@ class ClassMetadata {
     required this.isInParentExplicitSubtypes,
     required this.classElement,
     required this.allAnnotatedClasses,
+    this.agentDirectiveInfo = const AgentDirectiveInfo(),
     this.polymorphicSubtypes = const [],
   });
 

--- a/zorphy/lib/src/models/models.dart
+++ b/zorphy/lib/src/models/models.dart
@@ -4,3 +4,4 @@ export 'field_metadata.dart';
 export 'generation_config.dart';
 export 'interface_metadata.dart';
 export '../factory_method.dart' show FactoryMethodInfo;
+export 'agent_directive_info.dart';

--- a/zorphy/lib/src/orchestrator.dart
+++ b/zorphy/lib/src/orchestrator.dart
@@ -5,6 +5,7 @@ import 'package:zorphy/src/analysis/analysis.dart';
 import 'package:zorphy/src/ast/ast.dart';
 import 'package:zorphy/src/emission/emitter.dart';
 import 'package:zorphy/src/generators/generators.dart';
+import 'package:zorphy/src/generators/agent_directive_generator.dart';
 import 'package:zorphy/src/models/models.dart';
 import 'package:zorphy/src/plugins/plugin_context.dart';
 import 'package:zorphy/src/plugins/plugin_registry.dart';
@@ -56,6 +57,9 @@ class Orchestrator {
 
     // CompareTo extension (conditional, concrete only)
     CompareToExtensionGenerator(),
+
+    // Agent directive (conditional, has agent annotations)
+    AgentDirectiveGenerator(),
 
     // ChangeTo extension (conditional, has explicit subtypes)
     ChangeToExtensionGenerator(),

--- a/zorphy/pubspec.lock
+++ b/zorphy/pubspec.lock
@@ -557,9 +557,9 @@ packages:
     dependency: "direct main"
     description:
       name: zorphy_annotation
-      sha256: "50d3b39d0f376fbd84a9e0d8bfe006c771efe08079eb2caebf8536413f757fb6"
+      sha256: f20e9b830538ce58c8b3730cf8c57616124acb3c5abc7b78f69c30c20eec9554
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/zorphy/test/ast/spec_mapper_test.dart
+++ b/zorphy/test/ast/spec_mapper_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 import 'package:zorphy/src/ast/spec_mapper.dart';
 import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/interface_metadata.dart';
 
 // ────────────────────────────────────────────────────────────────────
@@ -55,7 +56,8 @@ ClassMetadata _testMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(cleanName),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/issue_103_custom_type_key_test.dart
+++ b/zorphy/test/generation/issue_103_custom_type_key_test.dart
@@ -23,6 +23,7 @@ import 'package:zorphy/src/common/classes.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/json_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 
 class _StubClassElement implements ClassElement {
@@ -59,7 +60,8 @@ ClassMetadata _baseMeta({
     explicitSubtypes: subtypes,
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 
@@ -88,7 +90,8 @@ ClassMetadata _subtypeMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: true,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/issue_105_bare_function_field_test.dart
+++ b/zorphy/test/generation/issue_105_bare_function_field_test.dart
@@ -30,6 +30,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/class_declaration_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 
 class _StubClassElement implements ClassElement {
@@ -62,7 +63,8 @@ ClassMetadata _concreteMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/issue_111_patch_nonsealed_test.dart
+++ b/zorphy/test/generation/issue_111_patch_nonsealed_test.dart
@@ -20,6 +20,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/patch_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 import 'package:zorphy/src/models/interface_metadata.dart';
 
@@ -58,7 +59,8 @@ ClassMetadata _meta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: isInParentExplicitSubtypes,
     classElement: _StubClassElement(cleanName),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/issue_114_agent_annotations_test.dart
+++ b/zorphy/test/generation/issue_114_agent_annotations_test.dart
@@ -1,0 +1,194 @@
+// Test for issue #114: agent annotations.
+//
+// Verifies that @AgentTool, @AgentRisk, @AgentInternal, @AgentExclude
+// produce an AgentDirective const in generated output.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import "package:zorphy_annotation/zorphy_annotation.dart" hide Field;
+import 'package:zorphy/src/common/NameType.dart';
+import 'package:zorphy/src/generators/base_generator.dart';
+import 'package:zorphy/src/generators/agent_directive_generator.dart';
+import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/generation_config.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
+
+class _StubClassElement implements ClassElement {
+  @override
+  final String name;
+  _StubClassElement(this.name);
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+ClassMetadata _concreteMeta({
+  required String name,
+  List<NameTypeClassComment> fields = const [],
+  AgentDirectiveInfo agentDirectiveInfo = const AgentDirectiveInfo(),
+}) {
+  return ClassMetadata(
+    originalName: name,
+    cleanName: name,
+    isAbstract: false,
+    isSealed: false,
+    nonSealed: false,
+    hasConstConstructor: false,
+    docComment: '',
+    generics: const [],
+    interfaces: const [],
+    allValueTInterfaces: const [],
+    allFields: fields,
+    ownFieldNames: fields.map((f) => f.name).toSet(),
+    factoryMethods: const [],
+    explicitSubtypes: const [],
+    isInParentExplicitSubtypes: false,
+    classElement: _StubClassElement(name),
+    allAnnotatedClasses: const {},
+    agentDirectiveInfo: agentDirectiveInfo,
+  );
+}
+
+GenerationConfig _bareConfig() {
+  return const GenerationConfig(
+    outputExtension: '.zorphy.dart',
+    preset: ZorphyPreset.standard,
+    kind: ZorphyKind.entity,
+    autoId: false,
+    generateJson: false,
+    explicitToJson: true,
+    generateCopyWith: true,
+    generateCopyWithFn: false,
+    generateCompareTo: false,
+    generatePatch: false,
+    hidePublicConstructor: false,
+    generateFilter: false,
+    generatePropertyHelpers: false,
+    generateEqualsToString: false,
+    generateChangeTo: false,
+    nonSealed: false,
+    factoryMethods: [],
+    ownFields: {},
+  );
+}
+
+String _emitSpecs(List<Spec> specs) {
+  final lib = Library((b) {
+    for (final spec in specs) {
+      if (spec is Field) b.body.add(spec);
+    }
+  });
+  return lib.accept(DartEmitter()).toString();
+}
+
+void main() {
+  group('Issue #114 agent annotations', () {
+    test('no directive when no agent annotations', () {
+      final meta = _concreteMeta(name: 'User');
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      expect(specs, isEmpty);
+    });
+
+    test('shouldGenerate returns false when no agent annotations', () {
+      final meta = _concreteMeta(name: 'User');
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      expect(AgentDirectiveGenerator().shouldGenerate(context), isFalse);
+    });
+
+    test('emits AgentDirective with risk tier', () {
+      final meta = _concreteMeta(
+        name: 'DeleteAccount',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          risk: 'confirm',
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      expect(specs, hasLength(1));
+      final code = _emitSpecs(specs);
+      expect(code, contains('agentDirective'));
+      expect(code, contains('AgentRiskTier.confirm'));
+    });
+
+    test('emits AgentDirective with admin risk', () {
+      final meta = _concreteMeta(
+        name: 'SystemConfig',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          risk: 'admin',
+          internal: true,
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      final code = _emitSpecs(specs);
+      expect(code, contains('AgentRiskTier.admin'));
+      expect(code, contains('internal: true'));
+    });
+
+    test('emits AgentDirective with tool override', () {
+      final meta = _concreteMeta(
+        name: 'CreateUser',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          toolName: 'create_user',
+          toolNamespace: 'users',
+          toolDescription: 'Create a new user',
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      final code = _emitSpecs(specs);
+      expect(code, contains("name: 'create_user'"));
+      expect(code, contains("namespace: 'users'"));
+      expect(code, contains("description: 'Create a new user'"));
+      expect(code, contains('AgentToolDirective'));
+    });
+
+    test('emits AgentDirective with exclude', () {
+      final meta = _concreteMeta(
+        name: 'InternalHelper',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          exclude: true,
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      final code = _emitSpecs(specs);
+      expect(code, contains('exclude: true'));
+    });
+
+    test('emits AgentDirective with param descriptions', () {
+      final meta = _concreteMeta(
+        name: 'SearchQuery',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          paramDescriptions: {'query': 'The search query string', 'limit': 'Max results to return'},
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      final code = _emitSpecs(specs);
+      expect(code, contains('AgentParamDirective'));
+      expect(code, contains("'query'"));
+      expect(code, contains("'limit'"));
+    });
+
+    test('safe risk tier is omitted from output (default)', () {
+      final meta = _concreteMeta(
+        name: 'Simple',
+        agentDirectiveInfo: const AgentDirectiveInfo(
+          hasAgentAnnotations: true,
+        ),
+      );
+      final context = GenerationContext(metadata: meta, config: _bareConfig());
+      final specs = AgentDirectiveGenerator().generateSpec(context);
+      final code = _emitSpecs(specs);
+      expect(code, contains('agentDirective'));
+      expect(code, isNot(contains('risk:')));
+    });
+  });
+}

--- a/zorphy/test/generation/issue_119_subtype_cast_test.dart
+++ b/zorphy/test/generation/issue_119_subtype_cast_test.dart
@@ -20,6 +20,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/patch_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 
 class _StubClassElement implements ClassElement {
@@ -52,7 +53,8 @@ ClassMetadata _concreteMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/issue_89_function_typed_getter_test.dart
+++ b/zorphy/test/generation/issue_89_function_typed_getter_test.dart
@@ -27,6 +27,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/class_declaration_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 
 class _StubClassElement implements ClassElement {
@@ -59,7 +60,8 @@ ClassMetadata _concreteMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/generation/spec_pipeline_constructor_this_prefix_test.dart
+++ b/zorphy/test/generation/spec_pipeline_constructor_this_prefix_test.dart
@@ -23,6 +23,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/generators/base_generator.dart';
 import 'package:zorphy/src/generators/class_declaration_generator.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 
 // ────────────────────────────────────────────────────────────────────
@@ -68,7 +69,8 @@ ClassMetadata _concreteMeta({
     explicitSubtypes: const [],
     isInParentExplicitSubtypes: false,
     classElement: _StubClassElement(name),
-    allAnnotatedClasses: const {},
+    agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: const {},
   );
 }
 

--- a/zorphy/test/plugin_pipeline_test.dart
+++ b/zorphy/test/plugin_pipeline_test.dart
@@ -5,6 +5,7 @@ import 'package:zorphy/src/common/NameType.dart';
 import 'package:zorphy/src/emission/emitter.dart';
 import 'package:zorphy/src/factory_method.dart';
 import 'package:zorphy/src/models/class_metadata.dart';
+import 'package:zorphy/src/models/agent_directive_info.dart';
 import 'package:zorphy/src/models/generation_config.dart';
 import 'package:zorphy/src/models/interface_metadata.dart';
 import 'package:zorphy/zorphy_plugin.dart';
@@ -143,7 +144,8 @@ class _FakeClassMetadata extends ClassMetadata {
           explicitSubtypes: <Interface>[],
           isInParentExplicitSubtypes: false,
           classElement: _FakeClassElement(),
-          allAnnotatedClasses: <String, ClassElement>{},
+          agentDirectiveInfo: const AgentDirectiveInfo(),
+      allAnnotatedClasses: <String, ClassElement>{},
         );
 }
 

--- a/zorphy_annotation/lib/src/agent_annotations.dart
+++ b/zorphy_annotation/lib/src/agent_annotations.dart
@@ -1,0 +1,167 @@
+/// Agent-centric architecture annotations for zorphy.
+///
+/// These annotations let developers declaratively control how zuraffa's
+/// AgentPlugin exposes entities/usecases as MCP tools. Annotations
+/// compile into an [AgentDirective] const in the generated `.zorphy.dart`
+/// file, which AgentPlugin consumes at analysis time.
+///
+/// See: https://github.com/arrrrny/zorphy/issues/114
+
+// ─────────────────────────────────────────────────────────────────
+// Risk tier
+// ─────────────────────────────────────────────────────────────────
+
+/// Risk tier for agent-exposed tools.
+///
+/// - [safe]: no confirmation required.
+/// - [confirm]: requires UI confirmation before execution.
+/// - [admin]: restricted to admin users; excluded from public manifests.
+enum AgentRiskTier { safe, confirm, admin }
+
+// ─────────────────────────────────────────────────────────────────
+// Class-level annotations
+// ─────────────────────────────────────────────────────────────────
+
+/// Override the generated MCP tool identity for an entity or usecase.
+///
+/// ```dart
+/// @AgentTool(name: 'create_user', namespace: 'users', description: 'Create a new user')
+/// @zorphy
+/// abstract class $CreateUser { ... }
+/// ```
+class AgentTool {
+  /// Optional tool name override. When null, the class name is used.
+  final String? name;
+
+  /// Optional namespace grouping for the tool (e.g. `'users'`).
+  final String? namespace;
+
+  /// Optional description shown in the tool schema.
+  final String? description;
+
+  /// Creates an agent tool identity override.
+  const AgentTool({this.name, this.namespace, this.description});
+}
+
+/// Declares the risk tier for an agent-exposed entity or usecase.
+///
+/// ```dart
+/// @AgentRisk(AgentRiskTier.confirm)
+/// @zorphy
+/// abstract class $DeleteAccount { ... }
+/// ```
+class AgentRisk {
+  /// The risk tier for this entity/usecase.
+  final AgentRiskTier value;
+
+  /// Creates an agent risk annotation.
+  const AgentRisk(this.value);
+}
+
+/// Sugar for `@AgentRisk(AgentRiskTier.admin)`.
+///
+/// Marks the entity/usecase as internal: restricted to admin users
+/// and excluded from public manifests.
+///
+/// ```dart
+/// @AgentInternal
+/// @zorphy
+/// abstract class $SystemConfig { ... }
+/// ```
+class AgentInternal {
+  /// Creates an agent-internal annotation.
+  const AgentInternal();
+}
+
+/// Marks an entity or usecase so it never becomes an MCP tool.
+///
+/// ```dart
+/// @AgentExclude
+/// @zorphy
+/// abstract class $InternalHelper { ... }
+/// ```
+class AgentExclude {
+  /// Creates an agent-exclude annotation.
+  const AgentExclude();
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Field-level annotations
+// ─────────────────────────────────────────────────────────────────
+
+/// Provides a description for a field when it appears as a tool parameter
+/// in the MCP inputSchema.
+///
+/// ```dart
+/// @AgentToolParam(description: 'The user\'s display name')
+/// String get displayName;
+/// ```
+class AgentToolParam {
+  /// Description for this parameter in the tool schema.
+  final String? description;
+
+  /// Creates an agent tool parameter annotation.
+  const AgentToolParam({this.description});
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Directive data class (emitted as const in generated files)
+// ─────────────────────────────────────────────────────────────────
+
+/// Typed directive consumed by zuraffa's AgentPlugin.
+///
+/// Zorphy emits a top-level `const agentDirective = AgentDirective(...)`
+/// in the generated `.zorphy.dart` file when any agent annotation is
+/// present on the abstract class. AgentPlugin scans for this const
+/// via AST analysis.
+///
+/// When no agent annotations are present, no directive is emitted.
+class AgentDirective {
+  /// Tool identity override (null when not annotated with @AgentTool).
+  final AgentToolDirective? tool;
+
+  /// Risk tier for the entity/usecase.
+  final AgentRiskTier risk;
+
+  /// Whether the entity/usecase is excluded from tool generation.
+  final bool exclude;
+
+  /// Whether this is an internal (admin-only) entity/usecase.
+  final bool internal;
+
+  /// Per-field parameter descriptions, keyed by field name.
+  final Map<String, AgentParamDirective> params;
+
+  /// Creates an agent directive.
+  const AgentDirective({
+    this.tool,
+    this.risk = AgentRiskTier.safe,
+    this.exclude = false,
+    this.internal = false,
+    this.params = const {},
+  });
+}
+
+/// Tool identity information within an [AgentDirective].
+class AgentToolDirective {
+  /// Optional tool name override.
+  final String? name;
+
+  /// Optional namespace grouping.
+  final String? namespace;
+
+  /// Optional tool description.
+  final String? description;
+
+  /// Creates an agent tool directive.
+  const AgentToolDirective({this.name, this.namespace, this.description});
+}
+
+/// Per-parameter metadata within an [AgentDirective].
+class AgentParamDirective {
+  /// Description for this parameter in the tool schema.
+  final String? description;
+
+  /// Creates an agent param directive.
+  const AgentParamDirective({this.description});
+}

--- a/zorphy_annotation/lib/zorphy_annotation.dart
+++ b/zorphy_annotation/lib/zorphy_annotation.dart
@@ -24,3 +24,4 @@ library zorphy_annotation;
 export 'zorphy.dart';
 export 'src/merge_mode.dart';
 export 'src/patch_base.dart';
+export 'src/agent_annotations.dart';


### PR DESCRIPTION
## Summary\n\nCloses #114\n\nAdds agent-centric architecture annotations for zuraffa AgentPlugin integration. Annotations compile into a typed const AgentDirective in generated .zorphy.dart files, consumable by AgentPlugin AST scan.\n\n### New Annotations\n\n- @AgentTool(name?, namespace?, description?) - Override generated MCP tool identity\n- @AgentRisk(AgentRiskTier) - Declare risk tier: safe, confirm, or admin\n- @AgentInternal - Sugar for @AgentRisk(admin) + excluded from public manifests\n- @AgentExclude - Entity/usecase never becomes a tool\n- @AgentToolParam(description?) - Field-level tool parameter description\n\n### Contract Types (in zorphy_annotation)\n\n- AgentRiskTier enum (safe, confirm, admin)\n- AgentDirective - top-level const emitted in generated files\n- AgentToolDirective - tool identity data\n- AgentParamDirective - per-parameter metadata\n\n### Test plan\n\n- [x] dart analyze - no new errors or warnings\n- [x] dart test - 8/8 new tests pass, 206/213 total (7 pre-existing fixture failures)\n- [ ] Integration test in zuraffa (AgentPlugin consumes emitted directive)