### PR TITLE
fix: resolve analyzer issues from #128 (unnecessary import + cast)

### DIFF
--- a/zorphy/lib/src/orchestrator.dart
+++ b/zorphy/lib/src/orchestrator.dart
@@ -5,7 +5,6 @@ import 'package:zorphy/src/analysis/analysis.dart';
 import 'package:zorphy/src/ast/ast.dart';
 import 'package:zorphy/src/emission/emitter.dart';
 import 'package:zorphy/src/generators/generators.dart';
-import 'package:zorphy/src/generators/agent_directive_generator.dart';
 import 'package:zorphy/src/models/models.dart';
 import 'package:zorphy/src/plugins/plugin_context.dart';
 import 'package:zorphy/src/plugins/plugin_registry.dart';

--- a/zorphy/test/generation/polymorphic_factory_param_recovery_test.dart
+++ b/zorphy/test/generation/polymorphic_factory_param_recovery_test.dart
@@ -35,7 +35,7 @@ Future<String> _recoverForParam(String methodName, String paramName) async {
   final ctx = collection.contextFor(f.path);
   final result =
       await ctx.currentSession.getResolvedUnit(f.path) as ResolvedUnitResult;
-  final lib = result.libraryElement as LibraryElement;
+  final lib = result.libraryElement;
   final el = lib.getClass('\$Base')!;
   for (final m in (el as dynamic).methods) {
     if ((m as dynamic).name == methodName) {


### PR DESCRIPTION
Follow-up to the merge of #128. After merging the value-equality fix, `dart analyze` on `master` flagged two issues that block the Dart CI `analyze_and_test` / `analyzer_compat` checks:

- `lib/src/orchestrator.dart`: the direct import of `agent_directive_generator.dart` became redundant once #128 added `export 'agent_directive_generator.dart'` to `generators.dart` (unnecessary_import).
- `test/generation/polymorphic_factory_param_recovery_test.dart`: `as LibraryElement` is an unnecessary cast under the current analyzer (unnecessary_cast).

No behavioral change; issue #127 is already closed by #128.