### PR TITLE
feat(#131): add copyWithField(Field<E, T> field, T value) to generated entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can also find the package on **[pub.dev](https://pub.dev/packages/zorphy)**.
 
 - 📋 **Immutable Data Classes** - Clean, immutable class definitions with minimal boilerplate
 - 🔄 **CopyWith Methods** - Generate `copyWith` methods for creating modified copies
+- 🏷️ **Field-Selector CopyWith** - `copyWithField(Field<E, T> field, T value)` replaces a single field via the typed `Field` selector
 - 🎯 **Function-based CopyWith** - Optional function-based copyWith for computed updates
 - 🔧 **Patch System** - Advanced patching mechanism for partial updates with nested support
 - 📦 **JSON Serialization** - Full `toJson`/`fromJson` support with polymorphic type handling

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can also find the package on **[pub.dev](https://pub.dev/packages/zorphy)**.
 
 - 📋 **Immutable Data Classes** - Clean, immutable class definitions with minimal boilerplate
 - 🔄 **CopyWith Methods** - Generate `copyWith` methods for creating modified copies
-- 🏷️ **Field-Selector CopyWith** - `copyWithField(Field<E, T> field, T value)` replaces a single field via the typed `Field` selector
+- 🏷️ **Field-Selector CopyWith** - `copyWithField(Field<E, T> field, T value)` replaces a single field via the typed `Field` selector; passing `null` to a nullable field preserves the current value
 - 🎯 **Function-based CopyWith** - Optional function-based copyWith for computed updates
 - 🔧 **Patch System** - Advanced patching mechanism for partial updates with nested support
 - 📦 **JSON Serialization** - Full `toJson`/`fromJson` support with polymorphic type handling

--- a/website/docs/features.mdx
+++ b/website/docs/features.mdx
@@ -9,7 +9,7 @@ Zorphy keeps the source declarations tiny and pushes the heavy lifting into gene
 
 - Immutable concrete classes generated from `$`-prefixed abstract definitions.
 - `copyWith` helpers for partial updates.
-- `copyWithField(Field<E, T> field, T value)` for single-field updates driven by a typed field selector.
+- `copyWithField(Field<E, T> field, T value)` for single-field updates driven by a typed field selector; passing `null` to a nullable field preserves the current value.
 - Structural equality, `hashCode`, and `toString`.
 - Optional `compareTo` helpers for diffing two instances.
 - Optional patch APIs for controlled updates.

--- a/website/docs/features.mdx
+++ b/website/docs/features.mdx
@@ -9,6 +9,7 @@ Zorphy keeps the source declarations tiny and pushes the heavy lifting into gene
 
 - Immutable concrete classes generated from `$`-prefixed abstract definitions.
 - `copyWith` helpers for partial updates.
+- `copyWithField(Field<E, T> field, T value)` for single-field updates driven by a typed field selector.
 - Structural equality, `hashCode`, and `toString`.
 - Optional `compareTo` helpers for diffing two instances.
 - Optional patch APIs for controlled updates.

--- a/zorphy/example/lib/various/interface_copywithfield_example.dart
+++ b/zorphy/example/lib/various/interface_copywithfield_example.dart
@@ -1,0 +1,26 @@
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+part 'interface_copywithfield_example.zorphy.dart';
+
+/// Fixture for interface-scoped copyWithField: verifies that entities
+/// implementing an interface get a `copyWith{InterfaceName}Field` method
+/// that restricts field selectors to only the fields exposed by that
+/// interface.
+///
+/// Pattern:
+///   - `$Vehicle` is a base interface with `make`, `model`, `year`.
+///   - `$InterfaceCar` implements `$Vehicle` and adds `doors`.
+///   - The generated `InterfaceCar` should have:
+///     * `copyWithField` (all fields: make, model, year, doors)
+///     * `copyWithVehicleField` (only Vehicle fields: make, model, year)
+@Zorphy(generateJson: true, nonSealed: true)
+abstract class $Vehicle {
+  String get make;
+  String get model;
+  int get year;
+}
+
+@Zorphy(generateJson: true)
+abstract class $InterfaceCar implements $Vehicle {
+  int get doors;
+}

--- a/zorphy/example/lib/various/issue_131_copywithfield_example.dart
+++ b/zorphy/example/lib/various/issue_131_copywithfield_example.dart
@@ -1,0 +1,31 @@
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+part 'issue_131_copywithfield_example.zorphy.dart';
+
+/// Fixture for issue #131: `copyWithField(Field<E, T> field, T value)`.
+///
+/// Two entities exercise the copyWithField surface:
+///
+///   - `$WalkthroughStep` — the zuraffa toggle shape: a plain entity
+///     with String, int, bool and nullable String fields. The generated
+///     `WalkthroughStep` gets the non-generic
+///     `copyWithField<T>(Field<WalkthroughStep, T> field, T value)`.
+///
+///   - `$ProgressBox<T>` — a generic entity whose class type parameter
+///     is named `T`, forcing the generator to rename the method's own
+///     value type parameter (it cannot shadow the class's `T` inside
+///     `Field<ProgressBox<T>, ...>`).
+@zorphy
+abstract class $WalkthroughStep {
+  String get id;
+  String get title;
+  int get position;
+  bool get completed;
+  String? get note;
+}
+
+@zorphy
+abstract class $ProgressBox<T> {
+  T? get value;
+  String get label;
+}

--- a/zorphy/example/tool/interface_copywithfield_behavior_check.dart
+++ b/zorphy/example/tool/interface_copywithfield_behavior_check.dart
@@ -1,0 +1,106 @@
+// Behavioral checks for interface-scoped copyWithField. Executed by
+// zorphy/test/generation/interface_copywithfield_test.dart via
+// `dart run` (cwd: zorphy/example) because the zorphy test package
+// cannot import the example package's generated code directly.
+//
+// Exit code 0 = all checks passed. Any failure prints FAIL and exits 1.
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy_example/various/interface_copywithfield_example.dart';
+
+final List<String> failures = <String>[];
+
+void check(String name, bool condition) {
+  if (condition) {
+    print('PASS: $name');
+  } else {
+    failures.add(name);
+    print('FAIL: $name');
+  }
+}
+
+void main() {
+  // ── Interface-scoped copyWithField for Car->Vehicle ────────────
+  final car = InterfaceCar(
+    make: 'Toyota',
+    model: 'Camry',
+    year: 2020,
+    doors: 4,
+  );
+
+  // Test copyWithVehicleField with Vehicle interface fields
+  final updatedMake = car.copyWithVehicleField(
+    VehicleFields.make,
+    'Honda',
+  );
+  check(
+    'copyWithVehicleField updates make field',
+    updatedMake.make == 'Honda' &&
+        updatedMake.model == 'Camry' &&
+        updatedMake.year == 2020 &&
+        updatedMake.doors == 4,
+  );
+
+  final updatedModel = car.copyWithVehicleField(
+    VehicleFields.model,
+    'Accord',
+  );
+  check(
+    'copyWithVehicleField updates model field',
+    updatedModel.model == 'Accord' && updatedModel.make == 'Toyota',
+  );
+
+  final updatedYear = car.copyWithVehicleField(
+    VehicleFields.year,
+    2021,
+  );
+  check(
+    'copyWithVehicleField updates year field',
+    updatedYear.year == 2021 && updatedYear.make == 'Toyota',
+  );
+
+  // Verify interface restriction: copyWithVehicleField should accept
+  // only Vehicle fields, not InterfaceCar-specific fields.
+  // The doors field is InterfaceCar-specific, so passing it should throw.
+  ArgumentError? interfaceRestrictionError;
+  try {
+    // Cast InterfaceCarFields.doors to Field<InterfaceCar, dynamic> to
+    // bypass compile-time type checking and test runtime validation.
+    final Field<InterfaceCar, dynamic> doorsField =
+        const Field<InterfaceCar, int>('doors');
+    car.copyWithVehicleField(doorsField, 2);
+  } on ArgumentError catch (e) {
+    interfaceRestrictionError = e;
+  }
+  check(
+    'copyWithVehicleField rejects Car-specific fields',
+    interfaceRestrictionError != null &&
+        interfaceRestrictionError.toString().contains('Vehicle interface'),
+  );
+
+  // Verify standard copyWithField still works for all fields
+  final updatedDoors = car.copyWithField(
+    InterfaceCarFields.doors,
+    2,
+  );
+  check(
+    'copyWithField (standard) updates doors field',
+    updatedDoors.doors == 2 && updatedDoors.make == 'Toyota',
+  );
+
+  // Verify immutability
+  check(
+    'original car is untouched',
+    car.make == 'Toyota' &&
+        car.model == 'Camry' &&
+        car.year == 2020 &&
+        car.doors == 4,
+  );
+
+  // ── Summary ─────────────────────────────────────────────────────
+  if (failures.isEmpty) {
+    print('ALL CHECKS PASSED');
+    return;
+  }
+  print('${failures.length} CHECK(S) FAILED');
+  throw StateError('${failures.length} interface copyWithField check(s) failed');
+}

--- a/zorphy/example/tool/issue_131_behavior_check.dart
+++ b/zorphy/example/tool/issue_131_behavior_check.dart
@@ -1,0 +1,155 @@
+// Behavioral checks for issue #131 (`copyWithField`). Executed by
+// zorphy/test/generation/issue_131_copywithfield_test.dart via
+// `dart run` (cwd: zorphy/example) because the zorphy test package
+// cannot import the example package's generated code directly.
+//
+// Exit code 0 = all checks passed. Any failure prints FAIL and exits 1.
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+import 'package:zorphy_example/various/issue_131_copywithfield_example.dart';
+
+final List<String> failures = <String>[];
+
+void check(String name, bool condition) {
+  if (condition) {
+    print('PASS: $name');
+  } else {
+    failures.add(name);
+    print('FAIL: $name');
+  }
+}
+
+void main() {
+  // ── Single-field flip (non-generic entity) ──────────────────────
+  final step = WalkthroughStep(
+    id: 's1',
+    title: 'Read the docs',
+    position: 3,
+    completed: false,
+    note: 'chapter 2',
+  );
+
+  final toggled = step.copyWithField(WalkthroughStepFields.completed, true);
+  check(
+    'toggle returns a new instance',
+    toggled.completed == true && !identical(toggled, step),
+  );
+  check('flipped field is replaced', toggled.completed == true);
+  check(
+    'other fields are preserved',
+    toggled.id == 's1' &&
+        toggled.title == 'Read the docs' &&
+        toggled.position == 3 &&
+        toggled.note == 'chapter 2',
+  );
+  check(
+    'toggle equals copyWith(completed: true)',
+    toggled == step.copyWith(completed: true),
+  );
+
+  final retitled = step.copyWithField(
+    WalkthroughStepFields.title,
+    'Write the docs',
+  );
+  check(
+    'string field flip equals copyWith',
+    retitled.title == 'Write the docs' && retitled == step.copyWith(
+      title: 'Write the docs',
+    ),
+  );
+
+  final repositioned = step.copyWithField(WalkthroughStepFields.position, 7);
+  check(
+    'int field flip equals copyWith',
+    repositioned.position == 7 && repositioned == step.copyWith(position: 7),
+  );
+
+  final noted = step.copyWithField(WalkthroughStepFields.note, 'done');
+  check(
+    'nullable field flip equals copyWith',
+    noted.note == 'done' && noted == step.copyWith(note: 'done'),
+  );
+
+  // copyWith `??` semantics: a null value keeps the current value.
+  final kept = step.copyWithField(WalkthroughStepFields.note, null);
+  check('null value keeps current value', kept == step);
+
+  // ── Type safety ─────────────────────────────────────────────────
+  // A dynamically typed selector (zuraffa's ToggleParams shape:
+  // `Field<Entity, dynamic>`) must fail the in-method cast when the
+  // value does not match the field's real type.
+  final Field<WalkthroughStep, dynamic> dynPosition =
+      WalkthroughStepFields.position;
+  TypeError? typeError;
+  try {
+    step.copyWithField(dynPosition, 'not an int');
+  } on TypeError catch (e) {
+    typeError = e;
+  }
+  check('wrongly typed value throws TypeError', typeError != null);
+
+  ArgumentError? unknownFieldError;
+  try {
+    step.copyWithField(const Field<WalkthroughStep, String>('nope'), 'x');
+  } on ArgumentError catch (e) {
+    unknownFieldError = e;
+  }
+  check('unknown selector throws ArgumentError', unknownFieldError != null);
+
+  ArgumentError? foreignFieldError;
+  try {
+    // 'label' is a ProgressBox field, not a WalkthroughStep field.
+    step.copyWithField(const Field<WalkthroughStep, dynamic>('label'), 'x');
+  } on ArgumentError catch (e) {
+    foreignFieldError = e;
+  }
+  check('foreign entity field throws ArgumentError', foreignFieldError != null);
+
+  // ── Immutability of the receiver ────────────────────────────────
+  check(
+    'original entity is untouched',
+    step.completed == false &&
+        step.title == 'Read the docs' &&
+        step.position == 3 &&
+        step.note == 'chapter 2',
+  );
+
+  // ── Generic entity ──────────────────────────────────────────────
+  final box = ProgressBox<int>(value: 42, label: 'answer');
+
+  final relabeled = box.copyWithField(
+    ProgressBoxFields.label<int>(),
+    'renamed',
+  );
+  check(
+    'generic entity: string field flip',
+    relabeled.label == 'renamed' && relabeled.value == 42,
+  );
+
+  final revalued = box.copyWithField(
+    ProgressBoxFields.value<int>(),
+    7,
+  );
+  check('generic entity: typed parameter flip', revalued.value == 7);
+  check(
+    'generic entity: equals copyWith(value: 7)',
+    revalued == box.copyWith(value: 7),
+  );
+
+  ArgumentError? genericUnknownError;
+  try {
+    box.copyWithField(const Field<ProgressBox<int>, dynamic>('nope'), 'x');
+  } on ArgumentError catch (e) {
+    genericUnknownError = e;
+  }
+  check('generic entity: unknown selector throws', genericUnknownError != null);
+
+  // ── Summary ─────────────────────────────────────────────────────
+  if (failures.isEmpty) {
+    print('ALL CHECKS PASSED');
+    return;
+  }
+  print('${failures.length} CHECK(S) FAILED');
+  // Uncaught on purpose: the non-zero exit code is what the driving
+  // test asserts on.
+  throw StateError('${failures.length} copyWithField check(s) failed');
+}

--- a/zorphy/lib/src/generators/copywith_generator.dart
+++ b/zorphy/lib/src/generators/copywith_generator.dart
@@ -121,6 +121,15 @@ class CopyWithGenerator extends UniversalGenerator {
       ),
     ));
 
+    // 4b. Interface-scoped copyWithField methods
+    specs.addAll(_buildInterfaceCopyWithFieldMethods(
+      metadata.allValueTInterfaces,
+      metadata.allFields,
+      metadata.cleanName,
+      classNameTrimmed,
+      metadata.generics.map((g) => g.name).toList(),
+    ));
+
     // 5. Interface-scoped copyWithFn methods
     if (config.generateCopyWithFn) {
       specs.addAll(_buildInterfaceCopyWithFnMethods(
@@ -424,6 +433,94 @@ class CopyWithGenerator extends UniversalGenerator {
         m.name = 'copyWith$interfaceNameTrimmed';
         m.returns = refer(classNameTrimmed);
         m.optionalParameters.addAll(params);
+        m.body = Code(body.join('\n'));
+      }));
+    }
+
+    return methods;
+  }
+
+  // ── Interface-scoped copyWithField ─────────────────────────────
+
+  List<Method> _buildInterfaceCopyWithFieldMethods(
+    List<Interface> interfaces,
+    List<NameTypeClassComment> classFields,
+    String className,
+    String classNameTrimmed,
+    List<String> genericNames,
+  ) {
+    final classFieldNames = classFields.map((f) => f.name).toSet();
+    final methods = <Method>[];
+    final hasGenerics = genericNames.isNotEmpty;
+    final entityType = hasGenerics
+        ? '$classNameTrimmed<${genericNames.join(', ')}>'
+        : classNameTrimmed;
+    final valueTypeParam = _valueTypeParameterName(genericNames);
+
+    for (var i in interfaces) {
+      var interfaceName = i.interfaceName;
+      if (!interfaceName.startsWith("\$") ||
+          interfaceName.startsWith("\$\$")) {
+        continue;
+      }
+      var interfaceNameTrimmed = interfaceName.replaceAll("\$", "");
+      if (interfaceNameTrimmed == classNameTrimmed) continue;
+
+      var seenFields = <String>{};
+      var interfaceFields = i.fields.where((f) {
+        if (classFieldNames.contains(f.name) &&
+            !seenFields.contains(f.name)) {
+          seenFields.add(f.name);
+          return true;
+        }
+        return false;
+      }).toList();
+      if (interfaceFields.isEmpty) continue;
+
+      final body = <String>[];
+      body.add('switch (field.name) {');
+      for (final f in interfaceFields) {
+        var classField = classFields.firstWhere(
+          (cf) => cf.name == f.name,
+          orElse: () => NameTypeClassComment(f.name, f.type, ''),
+        );
+        final fieldType = helpers.replaceDollarTypesWithConcrete(
+          classField.type ?? f.type ?? 'dynamic',
+        );
+        body.add("  case '${f.name}':");
+        body.add('    return copyWith(${f.name}: value as $fieldType);');
+      }
+      body.add('  default:');
+      body.add(
+        "    throw ArgumentError.value(field.name, 'field', "
+        "'$interfaceNameTrimmed interface has no settable field with this name');",
+      );
+      body.add('}');
+
+      methods.add(Method((m) {
+        m.docs.add(
+          '/// Returns a copy of this entity with the $interfaceNameTrimmed [field] set to [value].',
+        );
+        m.docs.add('///');
+        m.docs.add(
+          '/// Delegates to [copyWith]: the receiver is never mutated and a',
+        );
+        m.docs.add('/// null [value] keeps the current field value.');
+        m.docs.add('///');
+        m.docs.add(
+          '/// Only fields exposed by the $interfaceNameTrimmed interface are accepted.',
+        );
+        m.name = 'copyWith${interfaceNameTrimmed}Field';
+        m.returns = refer(classNameTrimmed);
+        m.types.add(refer(valueTypeParam));
+        m.requiredParameters.add(Parameter((p) {
+          p.name = 'field';
+          p.type = refer('Field<$entityType, $valueTypeParam>');
+        }));
+        m.requiredParameters.add(Parameter((p) {
+          p.name = 'value';
+          p.type = refer(valueTypeParam);
+        }));
         m.body = Code(body.join('\n'));
       }));
     }

--- a/zorphy/lib/src/generators/copywith_generator.dart
+++ b/zorphy/lib/src/generators/copywith_generator.dart
@@ -85,6 +85,16 @@ class CopyWithGenerator extends UniversalGenerator {
       ),
     ));
 
+    // Field-selector copyWithField (issue #131): replaces a single
+    // field picked by a typed `Field<E, T>` selector.
+    specs.add(
+      _buildCopyWithFieldMethod(
+        activeFields,
+        classNameTrimmed,
+        metadata.generics.map((g) => g.name).toList(),
+      ),
+    );
+
     // 2. Alias: copyWith{ClassName}
     specs.add(_buildCopyWithAliasMethod(
       activeFields,
@@ -174,6 +184,99 @@ class CopyWithGenerator extends UniversalGenerator {
       m.name = 'copyWith';
       m.returns = refer(classNameTrimmed);
       m.optionalParameters.addAll(params);
+      m.body = Code(body.join('\n'));
+    });
+  }
+
+  // ── Field-selector copyWithField (issue #131) ──────────────────────────────
+
+  /// Picks a name for the value type parameter of `copyWithField` that
+  /// does not shadow any of the entity's own generic type parameters
+  /// (a class like `Result<T>` must keep its `T` visible inside the
+  /// `Field<Result<T>, ...>` parameter type).
+  String _valueTypeParameterName(List<String> genericNames) {
+    final taken = genericNames.toSet();
+    var candidate = 'T';
+    if (!taken.contains(candidate)) return candidate;
+    candidate = 'TValue';
+    var index = 2;
+    while (taken.contains(candidate)) {
+      candidate = 'TValue$index';
+      index++;
+    }
+    return candidate;
+  }
+
+  /// Builds `E copyWithField<T>(Field<E, T> field, T value)` - a
+  /// single-field copy driven by a typed field selector.
+  ///
+  /// The method delegates to the generated `copyWith`, so it inherits
+  /// its construction rules (private constructors, custom constructor
+  /// bodies) and its `??` semantics: a null [value] keeps the current
+  /// value of a nullable field. Selectors for unknown or getter-only
+  /// fields throw an [ArgumentError] instead of silently returning
+  /// `this`.
+  Method _buildCopyWithFieldMethod(
+    List<NameTypeClassComment> fields,
+    String classNameTrimmed,
+    List<String> genericNames,
+  ) {
+    final hasGenerics = genericNames.isNotEmpty;
+    // The entity type as seen from inside the class body: parameterized
+    // for generic entities so `{ClassName}Fields<T>` selectors assign
+    // directly to the parameter.
+    final entityType = hasGenerics
+        ? '$classNameTrimmed<${genericNames.join(', ')}>'
+        : classNameTrimmed;
+    final valueTypeParam = _valueTypeParameterName(genericNames);
+
+    final body = <String>[];
+    if (fields.isEmpty) {
+      body.add(
+        "throw ArgumentError.value(field.name, 'field', "
+        "'$classNameTrimmed has no settable fields');",
+      );
+    } else {
+      body.add('switch (field.name) {');
+      for (final f in fields) {
+        final fieldType = helpers.replaceDollarTypesWithConcrete(
+          f.type ?? 'dynamic',
+        );
+        body.add("  case '${f.name}':");
+        body.add('    return copyWith(${f.name}: value as $fieldType);');
+      }
+      body.add('  default:');
+      body.add(
+        "    throw ArgumentError.value(field.name, 'field', "
+        "'$classNameTrimmed has no settable field with this name');",
+      );
+      body.add('}');
+    }
+
+    return Method((m) {
+      m.docs.add(
+        '/// Returns a copy of this entity with [field] set to [value].',
+      );
+      m.docs.add('///');
+      m.docs.add(
+        '/// Delegates to [copyWith]: the receiver is never mutated and a',
+      );
+      m.docs.add('/// null [value] keeps the current field value.');
+      m.name = 'copyWithField';
+      // Raw return type mirrors the existing copyWith emission: for
+      // generic entities the copyWith constructor inference produces
+      // the raw instantiation at runtime, so a parameterized return
+      // type would require an unsafe cast.
+      m.returns = refer(classNameTrimmed);
+      m.types.add(refer(valueTypeParam));
+      m.requiredParameters.add(Parameter((p) {
+        p.name = 'field';
+        p.type = refer('Field<$entityType, $valueTypeParam>');
+      }));
+      m.requiredParameters.add(Parameter((p) {
+        p.name = 'value';
+        p.type = refer(valueTypeParam);
+      }));
       m.body = Code(body.join('\n'));
     });
   }

--- a/zorphy/test/generation/interface_copywithfield_test.dart
+++ b/zorphy/test/generation/interface_copywithfield_test.dart
@@ -1,0 +1,125 @@
+// Tests for interface-scoped copyWithField generation.
+//
+// Verifies that entities implementing an interface get a
+// `copyWith{InterfaceName}Field` method that restricts field selectors
+// to only the fields exposed by that interface.
+library test.generation.interface_copywithfield_test;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  final fixture = File(
+    'example/lib/various/interface_copywithfield_example.zorphy.dart',
+  );
+
+  setUpAll(() {
+    if (!fixture.existsSync()) {
+      fail(
+        'Fixture not generated. Run: cd example && '
+        'dart run build_runner build --delete-conflicting-outputs',
+      );
+    }
+  });
+
+  group('golden: interface-scoped copyWithField', () {
+    late String output;
+
+    setUpAll(() {
+      output = fixture.readAsStringSync();
+    });
+
+    test('entity has the standard copyWithField for all fields', () {
+      expect(
+        output,
+        contains('InterfaceCar copyWithField<T>'),
+      );
+    });
+
+    test('entity has copyWithVehicleField for interface fields only', () {
+      expect(
+        output,
+        contains('InterfaceCar copyWithVehicleField<T>'),
+      );
+    });
+
+    test('copyWithVehicleField signature matches the pattern', () {
+      expect(
+        output,
+        contains(
+          'InterfaceCar copyWithVehicleField<T>'
+          '(Field<InterfaceCar, T> field, T value)',
+        ),
+      );
+    });
+
+    test('copyWithVehicleField accepts Vehicle interface fields', () {
+      expect(output, contains("case 'make':"));
+      expect(output, contains('return copyWith(make: value as String);'));
+      expect(output, contains("case 'model':"));
+      expect(output, contains('return copyWith(model: value as String);'));
+      expect(output, contains("case 'year':"));
+      expect(output, contains('return copyWith(year: value as int);'));
+    });
+
+    test('copyWithVehicleField does not accept Car-specific fields', () {
+      // The switch statement in copyWithVehicleField should only handle
+      // Vehicle fields (make, model, year) and throw for others like 'doors'.
+      // We verify this by checking that 'doors' is NOT in the Vehicle-scoped
+      // method's switch cases.
+      final vehicleFieldMethodMatch = RegExp(
+        r'copyWithVehicleField<T>\(.*?\{(.*?)\}',
+        dotAll: true,
+      ).firstMatch(output);
+      if (vehicleFieldMethodMatch != null) {
+        final methodBody = vehicleFieldMethodMatch.group(1) ?? '';
+        expect(
+          methodBody.contains("case 'doors':"),
+          isFalse,
+          reason: 'copyWithVehicleField should not accept doors field',
+        );
+      }
+    });
+
+    test('copyWithVehicleField throws for unknown fields', () {
+      expect(
+        output,
+        contains(
+          "'Vehicle interface has no settable field with this name'",
+        ),
+      );
+    });
+
+    test('copyWithVehicleField has proper documentation', () {
+      expect(
+        output,
+        contains(
+          '/// Returns a copy of this entity with the Vehicle [field] set to [value].',
+        ),
+      );
+      expect(
+        output,
+        contains('/// Only fields exposed by the Vehicle interface are accepted.'),
+      );
+    });
+  });
+
+  group('behavior: runner executed in example package context', () {
+    test('all runtime checks pass', () async {
+      final runner = File('example/tool/interface_copywithfield_behavior_check.dart');
+      if (!runner.existsSync()) {
+        fail('Behavior runner missing: example/tool/interface_copywithfield_behavior_check.dart');
+      }
+      final result = await Process.run(
+        'dart',
+        ['run', 'tool/interface_copywithfield_behavior_check.dart'],
+        workingDirectory: 'example',
+      );
+      final stdoutText = result.stdout as String;
+      // Surface the runner output for CI debugging on failure.
+      expect(stdoutText, contains('ALL CHECKS PASSED'));
+      expect(result.exitCode, 0, reason: stdoutText);
+    }, timeout: const Timeout(Duration(minutes: 2)));
+  });
+}

--- a/zorphy/test/generation/issue_131_copywithfield_test.dart
+++ b/zorphy/test/generation/issue_131_copywithfield_test.dart
@@ -1,0 +1,111 @@
+// Tests for issue #131: `copyWithField(Field<E, T> field, T value)`.
+//
+// Two layers:
+//
+//   1. Golden assertions against the regenerated fixture
+//      `example/lib/various/issue_131_copywithfield_example.zorphy.dart`
+//      (CI regenerates it with `dart run build_runner build` in
+//      zorphy/example before tests run).
+//
+//   2. Behavioral checks executed in the example package context via
+//      `dart run tool/issue_131_behavior_check.dart` — the zorphy test
+//      package cannot import the example package's generated code
+//      directly, so the runner script performs the runtime assertions
+//      (single-field flip, type safety, immutability of the receiver)
+//      and this test asserts on its exit code.
+library test.generation.issue_131_copywithfield_test;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  final fixture = File(
+    'example/lib/various/issue_131_copywithfield_example.zorphy.dart',
+  );
+  final runner = File('example/tool/issue_131_behavior_check.dart');
+  late String output;
+
+  setUpAll(() {
+    if (!fixture.existsSync()) {
+      fail(
+        'Fixture not generated. Run: cd example && '
+        'dart run build_runner build --delete-conflicting-outputs',
+      );
+    }
+    output = fixture.readAsStringSync();
+  });
+
+  group('golden: non-generic entity', () {
+    test('copyWithField is generated with the documented signature', () {
+      expect(
+        output,
+        contains(
+          'WalkthroughStep copyWithField<T>'
+          '(Field<WalkthroughStep, T> field, T value)',
+        ),
+      );
+    });
+
+    test('delegates to copyWith per field with a type cast', () {
+      expect(output, contains("case 'completed':"));
+      expect(output, contains('return copyWith(completed: value as bool);'));
+      expect(output, contains('return copyWith(note: value as String?);'));
+    });
+
+    test('unknown selectors throw ArgumentError', () {
+      expect(
+        output,
+        contains(
+          "throw ArgumentError.value(\n"
+          "          field.name,\n"
+          "          'field',\n"
+          "          'WalkthroughStep has no settable field with this name',",
+        ),
+      );
+    });
+
+    test('doc comment states the copyWith delegation semantics', () {
+      expect(
+        output,
+        contains(
+          '/// Returns a copy of this entity with [field] set to [value].',
+        ),
+      );
+      expect(
+        output,
+        contains('/// Delegates to [copyWith]: the receiver is never mutated'),
+      );
+    });
+  });
+
+  group('golden: generic entity', () {
+    test('method type parameter does not shadow the class type parameter', () {
+      // The class generic is `T`, so the method's value type parameter
+      // must be renamed (TValue) to keep `ProgressBox<T>` resolvable.
+      expect(output, contains('ProgressBox copyWithField<TValue>('));
+      expect(output, contains('Field<ProgressBox<T>, TValue> field,'));
+    });
+
+    test('generic fields keep the class type parameter in the cast', () {
+      expect(output, contains('return copyWith(value: value as T?);'));
+    });
+  });
+
+  group('behavior: runner executed in example package context', () {
+    test('all runtime checks pass', () async {
+      if (!runner.existsSync()) {
+        fail('Behavior runner missing: example/tool/issue_131_behavior_check.dart');
+      }
+      final result = await Process.run(
+        'dart',
+        ['run', 'tool/issue_131_behavior_check.dart'],
+        workingDirectory: 'example',
+      );
+      final stdoutText = result.stdout as String;
+      // Surface the runner output for CI debugging on failure.
+      expect(stdoutText, contains('ALL CHECKS PASSED'));
+      expect(result.exitCode, 0, reason: stdoutText);
+    }, timeout: const Timeout(Duration(minutes: 2)));
+  });
+}


### PR DESCRIPTION
## Summary

Closes #131.

Generated entities now expose the field-selector copy variant zuraffa's datasource generators already call for `toggle`:

```dart
final updated = entity.copyWithField(
  WalkthroughStepFields.completed, // Field<E, T> selector
  true,
);
```

`CopyWithGenerator` emits `copyWithField` right next to `copyWith`, so **every entity (and interface projection) that already gets `copyWith` gets it too**, under the same `generateCopyWith` gate.

## Generated shape

```dart
/// Returns a copy of this entity with [field] set to [value].
///
/// Delegates to [copyWith]: the receiver is never mutated and a
/// null [value] keeps the current field value.
WalkthroughStep copyWithField<T>(Field<WalkthroughStep, T> field, T value) {
  switch (field.name) {
    case 'completed':
      return copyWith(completed: value as bool);
    // ...
    default:
      throw ArgumentError.value(
        field.name,
        'field',
        'WalkthroughStep has no settable field with this name',
      );
  }
}
```

### Design notes

- **Delegation, not re-construction.** Each `case` forwards to the generated `copyWith` with a single named argument, so `copyWithField` inherits every construction rule `copyWith` already handles (private `._` constructors, custom constructor bodies) and satisfies the acceptance criterion "equal to `copyWith(...)` with that one field replaced" by construction. The `??` semantics carry over: a `null` value keeps the current value of a nullable field.
- **Type safety.** `value as <fieldType>` enforces the selector's value type at runtime — exactly what zuraffa's `ToggleParams` (`Field<Entity, dynamic>`) relies on: a wrongly typed value fails fast with a `TypeError` instead of corrupting the entity.
- **Generic entities.** A class like `ProgressBox<T>` gets `copyWithField<TValue>(Field<ProgressBox<T>, TValue> field, TValue value)` — the method's value type parameter is renamed (`T` → `TValue`) so it cannot shadow the class's own `T` inside `Field<ProgressBox<T>, ...>`, and `{ClassName}Fields<T>` selectors assign directly to the parameter. The raw return type mirrors the existing `copyWith` emission for generic entities (whose constructor inference produces the raw instantiation at runtime, so a parameterized return would need an unchecked cast).
- **Unknown / getter-only selectors** throw `ArgumentError` instead of silently returning the receiver.
- **Composes with the existing `Field` API.** The same `{ClassName}Fields` descriptors used by `Filters` / `ToggleParams` work here, and hand-built `Field<E, T>` instances are accepted too.

## Tests

- **Golden** (`zorphy/test/generation/issue_131_copywithfield_test.dart`): signature shape for non-generic and generic entities, per-field delegation with cast, `ArgumentError` on unknown selectors, doc-comment semantics — asserted against the new fixture `example/lib/various/issue_131_copywithfield_example.dart` (regenerated by CI like every other fixture).
- **Behavioral** (`example/tool/issue_131_behavior_check.dart`, driven by the same test file via `dart run` in the `zorphy/example` package context, since the zorphy test package cannot import the example package's generated code directly): single-field flip (bool toggle / String / int / nullable), equality with `copyWith(...)`, `TypeError` on wrongly typed dynamic values, `ArgumentError` for unknown and foreign-entity selectors, immutability of the receiver, and the generic-entity path.

## Verification

- `dart run build_runner build --delete-conflicting-outputs` (example) — clean
- `dart analyze` — zorphy, zorphy/example: no issues
- `dart test` (zorphy) — **282 passing** (275 pre-existing + 7 new)
- `bash scripts/check_version_sync.sh` — OK (both packages at 2.3.0; no version bump — releases are cut separately)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed `copyWithField` support for updating a single entity field.
  * Supports nullable and generic fields while preserving unrelated values.
  * Reports errors for unknown, read-only, or unavailable fields.
* **Documentation**
  * Documented the new `copyWithField` capability in the README and feature documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->