### PR TITLE
fix: escape special characters in @JsonKey name annotations

### DIFF
--- a/zorphy/lib/src/cli/entity_creator.dart
+++ b/zorphy/lib/src/cli/entity_creator.dart
@@ -367,7 +367,9 @@ class EntityCreator {
     for (final field in fields) {
       fieldBuffer.writeln();
       if (field.jsonName != null) {
-        fieldBuffer.writeln("  @JsonKey(name: '${field.jsonName}')");
+        fieldBuffer.writeln(
+          "  @JsonKey(name: '${EntityTemplateGenerator.escapeDartStringLiteral(field.jsonName!)}')",
+        );
       }
       fieldBuffer.writeln('  ${field.fullType} get ${field.name};');
     }

--- a/zorphy/lib/src/cli/generators/entity_template_generator.dart
+++ b/zorphy/lib/src/cli/generators/entity_template_generator.dart
@@ -7,8 +7,8 @@ class EntityTemplateGenerator {
 
   /// Escapes a string value for safe interpolation into a Dart string
   /// literal. Handles apostrophes, backslashes, quotes, dollar signs, and
-  /// line breaks. Mirrors `_escapeDartStringLiteral` in json_generator.dart.
-  static String _escapeDartStringLiteral(String value) {
+  /// line breaks. Mirrors `escapeDartStringLiteral` in json_generator.dart.
+  static String escapeDartStringLiteral(String value) {
     return value
         .replaceAll('\\', '\\\\') // backslash must be first
         .replaceAll("'", "\\'") // single quote
@@ -184,7 +184,7 @@ class EntityTemplateGenerator {
     if (config.generateFilter) annotationOptions.add('generateFilter: true');
     if (config.subtypeWireValue != null) {
       annotationOptions.add(
-        "subtypeWireValue: '${_escapeDartStringLiteral(config.subtypeWireValue!)}'",
+        "subtypeWireValue: '${escapeDartStringLiteral(config.subtypeWireValue!)}'",
       );
     }
 
@@ -236,11 +236,11 @@ class EntityTemplateGenerator {
     if (config.isNonSealed) options.add('nonSealed: true');
     if (config.generateFilter) options.add('generateFilter: true');
     if (config.typeKey != null) {
-      options.add("typeKey: '${_escapeDartStringLiteral(config.typeKey!)}'");
+      options.add("typeKey: '${escapeDartStringLiteral(config.typeKey!)}'");
     }
     if (config.subtypeWireValue != null) {
       options.add(
-        "subtypeWireValue: '${_escapeDartStringLiteral(config.subtypeWireValue!)}'",
+        "subtypeWireValue: '${escapeDartStringLiteral(config.subtypeWireValue!)}'",
       );
     }
 
@@ -327,7 +327,9 @@ class EntityTemplateGenerator {
     }
     for (final field in fields) {
       if (field.jsonName != null) {
-        buffer.writeln("  @JsonKey(name: '${field.jsonName}')");
+        buffer.writeln(
+          "  @JsonKey(name: '${escapeDartStringLiteral(field.jsonName!)}')",
+        );
       }
       buffer.writeln('  ${field.fullType} get ${field.name};');
     }


### PR DESCRIPTION
## Summary

Properly escape special characters in `@JsonKey(name:)` annotations when generating entity code.

## Problem

If a field's `jsonName` contained special characters (apostrophes, backslashes, dollar signs), the generated `@JsonKey(name:)` would produce invalid Dart code.

## Changes

- Made `escapeDartStringLiteral` in `EntityTemplateGenerator` public (was private)
- Applied escaping in `entity_creator.dart` when generating `@JsonKey(name:)` for interface fields
- Applied escaping in `entity_template_generator.dart` when generating `@JsonKey(name:)` for concrete classes

**Files changed:** 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated entity code for fields whose JSON names contain quotes, backslashes, dollar signs, or control characters.
  - JSON field annotations now preserve special characters correctly, preventing invalid generated code and improving serialization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->