### PR TITLE
feat(022): gym — real exercises for zorphy (warmup + lift-json-payload)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,8 @@ app.*.map.json
 .**
 # But allow .github directory for workflows
 !.github/
+# Allow the GYM training artifacts (spec 022 / issue #397) — the miki
+# GYM runner consumes .gym/gym.yaml from each package.
+!zorphy/.gym/
 .handoffs
 .contracts

--- a/zorphy/.gym/exercise-lift-json-payload.dart
+++ b/zorphy/.gym/exercise-lift-json-payload.dart
@@ -1,0 +1,303 @@
+/// GYM exercise — lift a legacy JSON payload into a typed Zorphy entity
+/// (graded).
+///
+/// Brief (spec 022 / issue #397, US2-S2): a genuine dev task, not a
+/// re-skinned unit test. A legacy catalog API returns the fixed payload at
+/// .gym/fixtures/catalog-payload.json (name/price/stock/tags). The
+/// exercise drives the zorphy toolchain the way an operator does:
+///
+///   1. Stage a throwaway target package (path deps into this monorepo).
+///   2. `zorphy_cli from-json -n Product payload.json` — infer the entity
+///      shape from the payload.
+///   3. `zorphy build` — generate the entity code (.zorphy.dart/.g.dart)
+///      and compile the target (build_runner + a probe run proves the
+///      generated class is real).
+///   4. Assert the state semantics on the generated class:
+///      `Product.fromJson(payload)` -> field-by-field `toJson()` equality
+///      with the original payload (the JSON round-trip), and `copyWith`
+///      changing exactly the requested field while preserving the rest.
+///
+/// Grading (FR-007): exit 0 => pass; exit non-zero => fail. Mis-fires
+/// (unexpected outcomes) write a structured DROP CARD
+/// (Did/Expected/Happened/Where) under .gym/.drops/ (FR-006) — see
+/// github.com/arrrrny/drop-card.
+///
+/// verifyCommand: `dart run .gym/exercise-lift-json-payload.dart`
+/// evaluate: exit 0 => pass; exit !=0 => fail
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// The zorphy package root (this checkout).
+final String _pkgRoot = _resolvePackageRoot();
+
+String _resolvePackageRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 8; i += 1) {
+    if (File(p.join(dir.path, 'bin', 'zorphy_cli.dart')).existsSync() &&
+        File(p.join(dir.path, 'pubspec.yaml')).existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  return Directory.current.path;
+}
+
+/// Outcome of one CLI invocation.
+class _RunResult {
+  _RunResult({required this.exitCode, required this.output});
+
+  final int exitCode;
+  final String output;
+}
+
+Future<_RunResult> _run(
+  String workingDir,
+  String executable,
+  List<String> args, {
+  bool shell = false,
+}) async {
+  final result = await Process.run(
+    executable,
+    args,
+    workingDirectory: workingDir,
+    runInShell: shell,
+  );
+  return _RunResult(
+    exitCode: result.exitCode,
+    output: '${result.stdout as String}${result.stderr as String}',
+  );
+}
+
+/// Entry point for the graded exercise.
+Future<void> main() async {
+  // ── SETUP (sandbox lifecycle — fail fast before any work) ──────────
+  final cli = p.join(_pkgRoot, 'bin', 'zorphy_cli.dart');
+  if (!File(cli).existsSync()) {
+    _fail(
+      'zorphy CLI entry not found at $cli — run this exercise from the '
+      'zorphy package root.',
+    );
+  }
+  final payloadFixture = File(
+    p.join(_pkgRoot, '.gym', 'fixtures', 'catalog-payload.json'),
+  );
+  if (!payloadFixture.existsSync()) {
+    _fail('Payload fixture missing: ${payloadFixture.path}');
+  }
+
+  final sandbox = Directory(
+    p.canonicalize(p.join(_pkgRoot, '.gym', '.sandbox', 'lift-json-payload')),
+  );
+  if (sandbox.existsSync()) {
+    await sandbox.delete(recursive: true);
+  }
+  await sandbox.create(recursive: true);
+  final target = sandbox.path;
+  final annotationPath = p.normalize(
+    p.join(_pkgRoot, '..', 'zorphy_annotation'),
+  );
+
+  await File(p.join(target, 'pubspec.yaml')).writeAsString('''
+name: zorphy_gym_target
+description: Sandbox target for the lift-json-payload GYM exercise.
+version: 0.0.1
+publish_to: none
+environment:
+  sdk: ^3.8.0
+dependencies:
+  json_annotation: ^4.8.0
+  zorphy_annotation:
+    path: ${annotationPath.replaceAll('\\', '/')}
+dev_dependencies:
+  build_runner: ^2.4.0
+  json_serializable: ^6.6.0
+  zorphy:
+    path: ${_pkgRoot.replaceAll('\\', '/')}
+dependency_overrides:
+  zorphy_annotation:
+    path: ${annotationPath.replaceAll('\\', '/')}
+''');
+  await Directory(p.join(target, 'bin')).create(recursive: true);
+  await payloadFixture.copy(p.join(target, 'payload.json'));
+
+  final pubGet = await _run(target, 'dart', ['pub', 'get']);
+  if (pubGet.exitCode != 0) {
+    _fail(
+      'SETUP ERROR: dart pub get failed in the sandbox target '
+      '(exit ${pubGet.exitCode}) — environment/setup problem, not a '
+      'graded failure.\n${pubGet.output}',
+    );
+  }
+
+  // ── Step 1: lift the payload into an entity (zorphy_cli from-json) ──
+  final fromJson = await _run(target, 'dart', [
+    cli,
+    'from-json',
+    '-n',
+    'Product',
+    'payload.json',
+  ]);
+  if (fromJson.exitCode != 0) {
+    _fail(
+      '`zorphy_cli from-json -n Product payload.json` exited '
+      '${fromJson.exitCode}.\n${fromJson.output}',
+    );
+  }
+  final entityFile = File(
+    p.join(
+      target,
+      'lib',
+      'src',
+      'domain',
+      'entities',
+      'product',
+      'product.dart',
+    ),
+  );
+  if (!entityFile.existsSync()) {
+    await _dropCard(
+      did: 'ran `zorphy_cli from-json -n Product payload.json` (exit 0)',
+      expected: 'lib/src/domain/entities/product/product.dart on disk',
+      happened: 'command reported success but the entity file is missing',
+      where: 'lift-json-payload, step 1 (from-json)',
+    );
+    _fail(
+      'Mis-fire: from-json exited 0 but the entity file is missing '
+      '(${entityFile.path}). DROP CARD written.',
+    );
+  }
+
+  // ── Step 2: generate + compile (zorphy build) ────────────────────────
+  final build = await _run(target, 'dart', [cli, 'build']);
+  if (build.exitCode != 0) {
+    _fail('`zorphy build` exited ${build.exitCode}.\n${build.output}');
+  }
+  for (final part in <String>['product.zorphy.dart', 'product.g.dart']) {
+    final partFile = File(
+      p.join(target, 'lib', 'src', 'domain', 'entities', 'product', part),
+    );
+    if (!partFile.existsSync()) {
+      await _dropCard(
+        did: 'ran `zorphy build` after from-json (exit 0)',
+        expected: 'generated part $part beside the entity',
+        happened: 'build reported success but the part is missing',
+        where: 'lift-json-payload, step 2 (build)',
+      );
+      _fail(
+        'Mis-fire: build exited 0 but $part is missing. DROP CARD '
+        'written.',
+      );
+    }
+  }
+
+  // ── Step 3: prove the generated class is real (probe) ───────────────
+  await File(p.join(target, 'bin', 'probe.dart')).writeAsString('''
+import 'package:zorphy_gym_target/src/domain/entities/product/product.dart';
+
+void main() {
+  const payload = <String, dynamic>{
+    'name': 'Espresso',
+    'price': 4.5,
+    'stock': 12,
+    'tags': ['hot', 'small'],
+  };
+  final product = Product.fromJson(payload);
+  if (product.name != 'Espresso' ||
+      product.price != 4.5 ||
+      product.stock != 12 ||
+      product.tags.length != 2 ||
+      product.tags[0] != 'hot' ||
+      product.tags[1] != 'small') {
+    throw StateError('typed fields mismatch: \\\${product.toJson()}');
+  }
+  final out = product.toJson();
+  for (final entry in payload.entries) {
+    if (!_eq(out[entry.key], entry.value)) {
+      throw StateError('round-trip mismatch at \\\${entry.key}: '
+          '\\\${out[entry.key]} != \\\${entry.value}');
+    }
+  }
+  final copied = product.copyWith(name: 'Latte');
+  if (copied.name != 'Latte' ||
+      copied.price != product.price ||
+      copied.stock != product.stock ||
+      copied.tags.length != product.tags.length) {
+    throw StateError('copyWith did not preserve untouched fields');
+  }
+  print('JSON_LIFT_OK: Product round-trips the payload and copyWith is '
+      'field-safe');
+}
+
+bool _eq(Object? a, Object? b) {
+  if (a is List && b is List) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (!_eq(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  return a == b;
+}
+''');
+
+  final probe = await _run(target, 'dart', ['run', 'bin/probe.dart']);
+  if (probe.exitCode != 0 || !probe.output.contains('JSON_LIFT_OK')) {
+    await _dropCard(
+      did: 'compiled the generated Product and ran the round-trip probe',
+      expected:
+          'JSON_LIFT_OK — typed fields, JSON round-trip equality, '
+          'copyWith field-safety',
+      happened: 'exit ${probe.exitCode}; output:\n${probe.output}',
+      where: 'lift-json-payload, step 3 (probe)',
+    );
+    _fail(
+      'The generated entity does not round-trip the payload.\n'
+      '${probe.output}',
+    );
+  }
+
+  stdout.writeln(
+    'EXERCISE PASSED: lift-json-payload — legacy JSON payload '
+    'lifted into a typed Zorphy entity; round-trip + copyWith proven.',
+  );
+  // Leave the sandbox in place for downstream inspection; wiped next run.
+  exit(0);
+}
+
+/// Write a structured DROP CARD (Did/Expected/Happened/Where) for a
+/// mis-fire — an unexpected outcome, as opposed to a clean failure.
+Future<void> _dropCard({
+  required String did,
+  required String expected,
+  required String happened,
+  required String where,
+}) async {
+  final dropsDir = Directory(p.join(_pkgRoot, '.gym', '.drops'));
+  await dropsDir.create(recursive: true);
+  final stamp = DateTime.now().toUtc().toIso8601String().replaceAll(':', '-');
+  final card = File(p.join(dropsDir.path, 'DROP-lift-json-payload-$stamp.md'));
+  await card.writeAsString('''
+# DROP CARD: lift-json-payload
+
+- **Did**: $did
+- **Expected**: $expected
+- **Happened**: $happened
+- **Where**: $where
+
+Recorded by `.gym/exercise-lift-json-payload.dart` (spec 022 / issue
+#397). Mis-fire convention: github.com/arrrrny/drop-card
+''');
+  stderr.writeln('DROP CARD written: ${card.path}');
+}
+
+/// Print a structured failure message and exit non-zero.
+void _fail(String message) {
+  stderr.writeln('EXERCISE FAILED: lift-json-payload — $message');
+  stderr.writeln('Mis-fire? Drop a card: github.com/arrrrny/drop-card');
+  exit(1);
+}

--- a/zorphy/.gym/fixtures/catalog-payload.json
+++ b/zorphy/.gym/fixtures/catalog-payload.json
@@ -1,0 +1,6 @@
+{
+  "name": "Espresso",
+  "price": 4.5,
+  "stock": 12,
+  "tags": ["hot", "small"]
+}

--- a/zorphy/.gym/gym.yaml
+++ b/zorphy/.gym/gym.yaml
@@ -1,0 +1,45 @@
+# GYM artifact — package-level exercises for zorphy.
+# See github.com/arrrrny/gym for the paradigm,
+#     github.com/arrrrny/miki (gym.mjs) for the runner that consumes this file.
+#
+# Mirrors the package-level gym.yaml shape established in
+# github.com/arrrrny/zuraffa (.gym/gym.yaml) so the miki GYM runner can
+# consume this package without code changes (spec 022 / issue #397).
+#
+# A gym is a folder of exercises with two phases:
+#   WARMUP    — mandatory reps that build reflex. No reps, no phase 2.
+#   EXERCISES — graded work that proves the muscle under real load.
+# The gate only lets the proven through. A mis-fire is a DROP CARD.
+name: zorphy
+version: 1.0.0
+warmup:
+  - id: 01-deps
+    name: Resolve package dependencies
+    command: dart run .gym/warmup/01-deps.dart
+  - id: 02-build
+    name: Self-build the package (codegen + compile)
+    command: dart run .gym/warmup/02-build.dart
+  - id: 03-smoke
+    name: Codegen round-trip smoke call into the zorphy CLI
+    command: dart run .gym/warmup/03-smoke.dart
+exercises:
+  - id: lift-json-payload
+    brief: |
+      A genuine dev task (spec 022 / issue #397), not a re-skinned unit
+      test: lift a legacy JSON API payload into a typed Zorphy entity and
+      prove its state semantics. Drive `zorphy_cli from-json` with the
+      fixed catalog payload fixture (fields inferred: name / price /
+      stock / tags), build the generated code, compile it, then assert
+      the generated `Product` round-trips the original JSON
+      (`fromJson` -> `toJson` field equality) and that `copyWith`
+      preserves every untouched field. Mis-fires emit a structured
+      DROP CARD (Did/Expected/Happened/Where) under .gym/.drops/ and
+      fail the run; grading is exit-code based.
+    setup: |
+      Ensure `dart` is on PATH.
+      Run the warmup reps first (.gym/warmup/*).
+      The exercise stages a temp target package under .gym/.sandbox/ —
+      it never mutates the zorphy source tree. The payload fixture
+      lives at .gym/fixtures/catalog-payload.json.
+    verifyCommand: dart run .gym/exercise-lift-json-payload.dart
+    evaluate: exit 0 => pass; exit !=0 => fail

--- a/zorphy/.gym/warmup/01-deps.dart
+++ b/zorphy/.gym/warmup/01-deps.dart
@@ -1,0 +1,60 @@
+/// GYM warmup rep #1 — resolve package dependencies (zorphy).
+///
+/// A warmup rep proves the operator can drive the package at all. This one
+/// resolves the zorphy package's own dependencies via `dart pub get` and
+/// asserts the produced `.dart_tool/package_config.json` is on disk and
+/// references the zorphy root package (the monorepo path-override to
+/// zorphy_annotation is part of the package's committed pubspec).
+///
+/// Run from the zorphy package root: `dart run .gym/warmup/01-deps.dart`
+///
+/// A mis-fire (unexpected outcome, not a clean failure) is a DROP CARD —
+/// see github.com/arrrrny/drop-card.
+library;
+
+import 'dart:io';
+
+/// Entry point for warmup rep #1.
+Future<void> main() async {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    stderr.writeln(
+      'No pubspec.yaml in cwd=${Directory.current.path} — run this rep '
+      'from the zorphy package root (zorphy/zorphy/).',
+    );
+    exit(1);
+  }
+
+  final result = await Process.run('dart', ['pub', 'get']);
+
+  if (result.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — `dart pub get` exited ${result.exitCode}',
+    );
+    stderr.writeln(result.stdout);
+    stderr.writeln(result.stderr);
+    exit(result.exitCode == 0 ? 1 : result.exitCode);
+  }
+
+  final pkgConfig = File('.dart_tool/package_config.json');
+  if (!pkgConfig.existsSync()) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — pub get exited 0 but '
+      '.dart_tool/package_config.json is missing. Mis-fire — drop a card: '
+      'github.com/arrrrny/drop-card',
+    );
+    exit(1);
+  }
+
+  final configText = pkgConfig.readAsStringSync();
+  if (!configText.contains('"name":"zorphy"') &&
+      !configText.contains('"name": "zorphy"')) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — package_config.json does not reference the '
+      '`zorphy` root package. Mis-fire — drop a card.',
+    );
+    exit(1);
+  }
+
+  stdout.writeln('REP OK: 01-deps — dependencies resolved.');
+}

--- a/zorphy/.gym/warmup/02-build.dart
+++ b/zorphy/.gym/warmup/02-build.dart
@@ -1,0 +1,47 @@
+/// GYM warmup rep #2 — self-build the zorphy package (codegen + compile).
+///
+/// zorphy is a codegen package, so "build" means running its own
+/// source-generation over the committed sources (`build_runner build`)
+/// and proving the package's own `lib/` compiles with zero analyzer
+/// errors afterwards. The example/ tree carries pre-existing issues on a
+/// fresh checkout (missing optional deps) and is deliberately out of the
+/// rep's scope — the rep gates on the package surface an operator uses.
+///
+/// Run from the zorphy package root: `dart run .gym/warmup/02-build.dart`
+///
+/// A mis-fire (unexpected outcome, not a clean failure) is a DROP CARD —
+/// see github.com/arrrrny/drop-card.
+library;
+
+import 'dart:io';
+
+/// Entry point for warmup rep #2.
+Future<void> main() async {
+  final build = await Process.run('dart', [
+    'run',
+    'build_runner',
+    'build',
+    '--delete-conflicting-outputs',
+  ]);
+  if (build.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 02-build — build_runner exited ${build.exitCode}',
+    );
+    stderr.writeln(build.stdout);
+    stderr.writeln(build.stderr);
+    exit(build.exitCode == 0 ? 1 : build.exitCode);
+  }
+
+  final analyze = await Process.run('dart', ['analyze', 'lib']);
+  final out = '${analyze.stdout as String}${analyze.stderr as String}';
+  if (out.contains(' error - ')) {
+    stderr.writeln(
+      'REP FAIL: 02-build — self-build completed but `dart analyze lib` '
+      'reports errors (the package does not compile).',
+    );
+    stderr.writeln(out);
+    exit(1);
+  }
+
+  stdout.writeln('REP OK: 02-build — codegen ran and lib/ compiles clean.');
+}

--- a/zorphy/.gym/warmup/03-smoke.dart
+++ b/zorphy/.gym/warmup/03-smoke.dart
@@ -1,0 +1,172 @@
+/// GYM warmup rep #3 — codegen round-trip smoke call into the zorphy CLI.
+///
+/// The issue asks for "one authenticated smoke call" per package. zorphy
+/// is a codegen package, not a service, so the equivalent of an
+/// authenticated API call is driving the package's public CLI surface end
+/// to end — the same adaptation zuraffa's .gym/warmup/03-smoke.dart made
+/// for its codegen API. This rep scaffolds a throwaway target package,
+/// creates an entity via `zorphy_cli create`, runs `zorphy build` over it,
+/// and asserts the generated `.zorphy.dart` part landed with the public
+/// capabilities an operator relies on (`fromJson`, `copyWith`).
+///
+/// Run from the zorphy package root: `dart run .gym/warmup/03-smoke.dart`
+///
+/// A mis-fire (unexpected outcome, not a clean failure) is a DROP CARD —
+/// see github.com/arrrrny/drop-card.
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// The zorphy package root (this checkout).
+final String _pkgRoot = _resolvePackageRoot();
+
+String _resolvePackageRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 8; i += 1) {
+    if (File(p.join(dir.path, 'bin', 'zorphy_cli.dart')).existsSync() &&
+        File(p.join(dir.path, 'pubspec.yaml')).existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  return Directory.current.path;
+}
+
+/// Entry point for warmup rep #3.
+Future<void> main() async {
+  final sandbox = Directory(
+    p.canonicalize(p.join(_pkgRoot, '.gym', '.sandbox', 'warmup-03-smoke')),
+  );
+  if (sandbox.existsSync()) {
+    await sandbox.delete(recursive: true);
+  }
+  await sandbox.create(recursive: true);
+
+  final annotationPath = p.normalize(
+    p.join(_pkgRoot, '..', 'zorphy_annotation'),
+  );
+
+  // Throwaway target package: minimal consumer of the zorphy toolchain.
+  await File(p.join(sandbox.path, 'pubspec.yaml')).writeAsString('''
+name: zorphy_smoke_target
+description: Throwaway target for the zorphy GYM smoke rep.
+version: 0.0.1
+publish_to: none
+environment:
+  sdk: ^3.8.0
+dependencies:
+  zorphy_annotation:
+    path: ${annotationPath.replaceAll('\\', '/')}
+dev_dependencies:
+  build_runner: ^2.4.0
+  zorphy:
+    path: ${_pkgRoot.replaceAll('\\', '/')}
+dependency_overrides:
+  zorphy_annotation:
+    path: ${annotationPath.replaceAll('\\', '/')}
+''');
+
+  final pubGet = await Process.run('dart', [
+    'pub',
+    'get',
+  ], workingDirectory: sandbox.path);
+  if (pubGet.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 03-smoke — dart pub get failed in the smoke '
+      'target (setup error, not a grade).',
+    );
+    stderr.writeln(pubGet.stdout);
+    stderr.writeln(pubGet.stderr);
+    exit(1);
+  }
+
+  // The smoke call: create an entity through the public CLI.
+  final create = await Process.run('dart', [
+    p.join(_pkgRoot, 'bin', 'zorphy_cli.dart'),
+    'create',
+    '-n',
+    'Order',
+    '--field',
+    'id:String',
+    '--field',
+    'label:String',
+  ], workingDirectory: sandbox.path);
+  if (create.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 03-smoke — `zorphy_cli create` exited '
+      '${create.exitCode}',
+    );
+    stderr.writeln(create.stdout);
+    stderr.writeln(create.stderr);
+    exit(1);
+  }
+
+  final entityFile = File(
+    p.join(
+      sandbox.path,
+      'lib',
+      'src',
+      'domain',
+      'entities',
+      'order',
+      'order.dart',
+    ),
+  );
+  if (!entityFile.existsSync()) {
+    stderr.writeln(
+      'REP FAIL: 03-smoke — create exited 0 but the entity file is missing '
+      '(${entityFile.path}). Mis-fire — drop a card: '
+      'github.com/arrrrny/drop-card',
+    );
+    exit(1);
+  }
+
+  // Round-trip: run the generator over the target.
+  final build = await Process.run('dart', [
+    p.join(_pkgRoot, 'bin', 'zorphy_cli.dart'),
+    'build',
+  ], workingDirectory: sandbox.path);
+  if (build.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 03-smoke — `zorphy build` exited ${build.exitCode}',
+    );
+    stderr.writeln(build.stdout);
+    stderr.writeln(build.stderr);
+    exit(1);
+  }
+
+  final part = File(
+    p.join(
+      sandbox.path,
+      'lib',
+      'src',
+      'domain',
+      'entities',
+      'order',
+      'order.zorphy.dart',
+    ),
+  );
+  if (!part.existsSync()) {
+    stderr.writeln(
+      'REP FAIL: 03-smoke — build exited 0 but the generated part is '
+      'missing (${part.path}). Mis-fire — drop a card.',
+    );
+    exit(1);
+  }
+  final generated = part.readAsStringSync();
+  for (final marker in <String>['fromJson', 'copyWith']) {
+    if (!generated.contains(marker)) {
+      stderr.writeln(
+        'REP FAIL: 03-smoke — generated part is missing the "$marker" '
+        'capability. Mis-fire — drop a card.',
+      );
+      exit(1);
+    }
+  }
+
+  stdout.writeln('REP OK: 03-smoke — zorphy codegen round-trip OK.');
+}


### PR DESCRIPTION
## Summary
Stands up `zorphy/zorphy/.gym/` (issue #397, tracked by zuraffa spec 022) with a miki-GYM-runner-consumable `gym.yaml`: three mandatory warmup reps (dependency resolution; self-build via `build_runner build` + `dart analyze lib` with zero errors; a codegen round-trip smoke call through the public `zorphy_cli` surface) gating one graded exercise — **lift-json-payload**: a genuine dev task that lifts the fixed legacy JSON catalog payload (`.gym/fixtures/catalog-payload.json`) into a typed Zorphy entity via `zorphy_cli from-json`, builds and compiles it, then asserts the generated `Product` round-trips the original JSON (`fromJson`→`toJson` field equality) and that `copyWith` preserves every untouched field. Mis-fires emit structured DROP CARDs (Did/Expected/Happened/Where) under `.gym/.drops/`; grading is exit-code based. Exercises run in an isolated `.gym/.sandbox/` and never mutate source.

Also adds a scoped `.gitignore` negation (`!zorphy/.gym/`) so the gym tree is committable under the repo's hidden-directory rule.

## Test plan
- [x] `dart run .gym/warmup/01-deps.dart` → REP OK (exit 0)
- [x] `dart run .gym/warmup/02-build.dart` → REP OK (exit 0)
- [x] `dart run .gym/warmup/03-smoke.dart` → REP OK (exit 0)
- [x] `dart run .gym/exercise-lift-json-payload.dart` → EXERCISE PASSED (exit 0), after red evidence (probe import failure fixed) and a forced mis-fire verifying the DROP CARD path (exit 1 + card with all four fields)
- [x] `dart analyze .gym/` → No issues found (scripts are analyzer-clean under the repo's own CI gate)

Part of the four-package GYM rollout (zuraffa, zorphy, zikzak_inappwebview, vendure-flutter-sdk) tracked in arrrrny/zuraffa#397 / spec 022.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for dependency setup, code generation, compilation, and analyzer health.
  * Added a smoke test covering entity creation and generated `fromJson` and `copyWith` functionality.
  * Added a graded test for generating a typed `Product` entity from a JSON catalog payload.
  * Added fixture data for an Espresso product, including price, stock, and tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->